### PR TITLE
fix(ContextMenuItem): hide all overflow, not only overflow-x

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -149,7 +149,7 @@
 
 .ax-context-menu__item-content {
   flex: 1 1 auto;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .ax-context-menu__item-checkbox {


### PR DESCRIPTION
In https://github.com/BrandwatchLtd/axiom-react/pull/704 we added  `overflow-x: hidden` which unexpectetly causes `overflow-y` to compute to `auto` ( see note on [here](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y) ) causing scroll bars to show everywhere, where a `ContextMenuItem` have filled with more content that there was space available.

This PR will also set `overflow-y: hidden` to guard against scrollbars in these cases.