### PR TITLE
docs: Add "Better Together" colour

### DIFF
--- a/packages/axiom-materials/src/colors.css
+++ b/packages/axiom-materials/src/colors.css
@@ -198,5 +198,7 @@
   --color-social-instagram--active: rgb(171, 58, 133);
   --color-social-instagram: rgb(183, 71, 146);
   --color-social-instagram--hover: rgb(196, 86, 160);
+
+  --color-better-together: rgb(240, 78, 78);
 }
 /* stylelint-enable */

--- a/packages/axiom-materials/src/colors.js
+++ b/packages/axiom-materials/src/colors.js
@@ -171,6 +171,8 @@ export const socialInstagramActive = { r: 171, g: 58, b: 133 };
 export const socialInstagram = { r: 183, g: 71, b: 146 };
 export const socialInstagramHover = { r: 196, g: 86, b: 160 };
 
+export const betterTogether = { r: 240, g: 78, b: 78 };
+
 export const externalTwiiterBlue = socialTwitter;
 
 export const themeDayMain = uiCarbon;

--- a/site/components/Documentation/Resources/Materials/Colors.js
+++ b/site/components/Documentation/Resources/Materials/Colors.js
@@ -30,7 +30,14 @@ export default class Documentation extends Component {
   render() {
     return (
       <Fragment>
-        Click on a colour to copy the variable to your clipboard
+        Tip: You can click on a colour dot to copy the variable name to your clipboard!
+
+        <ColorGrid name="Brandwatch + Crimson Hexagon">
+          <ColorSet name="Better Together">
+            <ColorDot onClick={ () => this.copyColorToClipboard('var(--color-better-together)') } rgb={ colors.betterTogether }/>
+          </ColorSet>
+        </ColorGrid>
+
         <ColorGrid name="UI Colours">
           <ColorSet name="Carbon">
             <ColorDot name="Darker" onClick={ () => this.copyColorToClipboard('var(--color-ui-carbon--darker)') } rgb={ colors.uiCarbonDarker }/>

--- a/site/components/Documentation/Resources/Materials/Colors/ColorGrid.css
+++ b/site/components/Documentation/Resources/Materials/Colors/ColorGrid.css
@@ -8,6 +8,11 @@
   margin: 0 auto;
   border: 0.0625rem solid var(--color-theme-border);
   border-radius: 50%;
+  cursor: pointer;
+}
+
+.si-color-dot:active {
+  box-shadow: 0 0 0 0.25rem var(--color-theme-border);
 }
 
 .si-color-letter {


### PR DESCRIPTION
<img width="898" alt="screen shot 2019-02-27 at 2 31 45 pm" src="https://user-images.githubusercontent.com/160936/53497770-d424c700-3a9c-11e9-8636-83594ce86dcf.png">

This also adds a little but of positive feedback to click on a color to get the variable name in your clipboard