### PR TITLE
Adding "paddingVertical" property to "ContextMenuItem"

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -11,6 +11,7 @@
   --cmp-context-padding-medium: calc(var(--spacing-grid-size) * 4);
   --cmp-context-padding-large: calc(var(--spacing-grid-size) * 6);
   --cmp-context-menu-item-padding-vertical: calc(var(--spacing-grid-size) * 3);
+  --cmp-context-menu-item-padding-vertical-small: calc(var(--spacing-grid-size) * 1.5);
 }
 
 .ax-context {
@@ -123,7 +124,6 @@
   display: flex;
   align-items: center;
   width: 100%;
-  padding: var(--cmp-context-menu-item-padding-vertical) var(--cmp-context-padding-large);
   outline: 0;
   border: 0;
   background-color: var(--color-theme-background);
@@ -132,6 +132,14 @@
   transition-property: background-color, color;
   transition-duration: var(--transition-time-base);
   transition-timing-function: var(--transition-function);
+}
+
+.ax-context-menu__item--padding-vertical-medium {
+  padding: var(--cmp-context-menu-item-padding-vertical) var(--cmp-context-padding-large);
+}
+
+.ax-context-menu__item--padding-vertical-small {
+  padding: var(--cmp-context-menu-item-padding-vertical-small) var(--cmp-context-padding-large);
 }
 
 .ax-context-menu__item:focus {

--- a/packages/axiom-components/src/Context/ContextMenuItem.js
+++ b/packages/axiom-components/src/Context/ContextMenuItem.js
@@ -15,7 +15,12 @@ export default class ContextMenuItem extends Component {
     indeterminate: PropTypes.bool,
     multiSelect: PropTypes.bool,
     onClick: PropTypes.func,
+    paddingVertical: PropTypes.oneOf(['small', 'medium']),
     selected: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    paddingVertical: 'medium',
   };
 
   render() {
@@ -27,12 +32,15 @@ export default class ContextMenuItem extends Component {
       onClick,
       multiSelect,
       selected,
+      paddingVertical,
       ...rest
     } = this.props;
 
-    const classes = classnames('ax-context-menu__item', {
-      'ax-context-menu__item--selected': selected,
-    });
+    const classes = classnames(
+      'ax-context-menu__item',
+      `ax-context-menu__item--padding-vertical-${paddingVertical}`, {
+        'ax-context-menu__item--selected': selected,
+      });
 
     return (
       <Base { ...rest } { ...{ [contextMenuItemSelector]: true } }

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenu.test.js.snap
@@ -17,7 +17,7 @@ exports[`ContextMenu renders with defaultProps 1`] = `
       className="ax-context-menu ax-context-menu--padding-vertical-medium"
     >
       <button
-        className="ax-context-menu__item"
+        className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium"
         data-ax-context-menu-item={true}
       >
         <div

--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextMenuItem renders with custom icon 1`] = `
 <button
-  className="ax-context-menu__item"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium"
   data-ax-context-menu-item={true}
 >
   <div
@@ -34,7 +34,7 @@ exports[`ContextMenuItem renders with custom icon 1`] = `
 
 exports[`ContextMenuItem renders with defaultProps 1`] = `
 <button
-  className="ax-context-menu__item"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium"
   data-ax-context-menu-item={true}
 >
   <div
@@ -47,7 +47,7 @@ exports[`ContextMenuItem renders with defaultProps 1`] = `
 
 exports[`ContextMenuItem renders with disabled 1`] = `
 <button
-  className="ax-context-menu__item"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium"
   data-ax-context-menu-item={true}
   disabled={true}
 >
@@ -61,7 +61,7 @@ exports[`ContextMenuItem renders with disabled 1`] = `
 
 exports[`ContextMenuItem renders with multiSelect 1`] = `
 <button
-  className="ax-context-menu__item"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium"
   data-ax-context-menu-item={true}
 >
   <div
@@ -91,7 +91,7 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
 
 exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
 <button
-  className="ax-context-menu__item ax-context-menu__item--selected ax-text--strong"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium ax-context-menu__item--selected ax-text--strong"
   data-ax-context-menu-item={true}
 >
   <div
@@ -121,7 +121,7 @@ exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
 
 exports[`ContextMenuItem renders with multiSelect and title 1`] = `
 <button
-  className="ax-context-menu__item"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium"
   data-ax-context-menu-item={true}
   title="Lorem ipsum dolor sit amet"
 >
@@ -152,7 +152,7 @@ exports[`ContextMenuItem renders with multiSelect and title 1`] = `
 
 exports[`ContextMenuItem renders with selected 1`] = `
 <button
-  className="ax-context-menu__item ax-context-menu__item--selected ax-text--strong"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium ax-context-menu__item--selected ax-text--strong"
   data-ax-context-menu-item={true}
 >
   <div
@@ -184,7 +184,7 @@ exports[`ContextMenuItem renders with selected 1`] = `
 
 exports[`ContextMenuItem renders with title 1`] = `
 <button
-  className="ax-context-menu__item"
+  className="ax-context-menu__item ax-context-menu__item--padding-vertical-medium"
   data-ax-context-menu-item={true}
   title="Lorem ipsum dolor sit amet"
 >

--- a/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
+++ b/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
@@ -20,6 +20,8 @@ export default class DropdownMenuItem extends Component {
     multiSelect: PropTypes.bool,
     /** Click handler  */
     onClick: PropTypes.func,
+    /**  Vertical padding size applied to the menu item */
+    paddingVertical: PropTypes.oneOf(['small', 'medium']),
     /** Provides indication that the menu item is selected */
     selected: PropTypes.bool,
   };

--- a/packages/axiom-components/src/Dropdown/__snapshots__/DropdownMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Dropdown/__snapshots__/DropdownMenuItem.test.js.snap
@@ -3,6 +3,7 @@
 exports[`DropdownMenuItem Snapshots renders with defaultProps 1`] = `
 <ContextMenuItem
   onClick={[Function]}
+  paddingVertical="medium"
   tabIndex="0"
 >
   Test
@@ -13,6 +14,7 @@ exports[`DropdownMenuItem Snapshots renders with disabled 1`] = `
 <ContextMenuItem
   disabled={true}
   onClick={[Function]}
+  paddingVertical="medium"
   tabIndex="0"
 >
   Test
@@ -23,6 +25,7 @@ exports[`DropdownMenuItem Snapshots renders with index 1`] = `
 <ContextMenuItem
   index="1"
   onClick={[Function]}
+  paddingVertical="medium"
   tabIndex="0"
 >
   Test
@@ -32,6 +35,7 @@ exports[`DropdownMenuItem Snapshots renders with index 1`] = `
 exports[`DropdownMenuItem Snapshots renders with keepOpen 1`] = `
 <ContextMenuItem
   onClick={[Function]}
+  paddingVertical="medium"
   tabIndex="0"
 >
   Test
@@ -42,6 +46,7 @@ exports[`DropdownMenuItem Snapshots renders with multiSelect 1`] = `
 <ContextMenuItem
   multiSelect={true}
   onClick={[Function]}
+  paddingVertical="medium"
   tabIndex="0"
 >
   Test
@@ -51,6 +56,7 @@ exports[`DropdownMenuItem Snapshots renders with multiSelect 1`] = `
 exports[`DropdownMenuItem Snapshots renders with onClick 1`] = `
 <ContextMenuItem
   onClick={[Function]}
+  paddingVertical="medium"
   tabIndex="0"
 >
   Test
@@ -61,6 +67,7 @@ exports[`DropdownMenuItem Snapshots renders with onMouseOver 1`] = `
 <ContextMenuItem
   onClick={[Function]}
   onMouseOver={[Function]}
+  paddingVertical="medium"
   tabIndex="0"
 >
   Test


### PR DESCRIPTION
This PR is adding a `paddingVertical` property to the `ContextMenuItem` component. The default will be set to `medium`. I'm only adding a `small` option as this is what we need. We can probably extend this as soon as other variations will be used as well.
I've changed `DropdownMenuItem` to contain `paddingVertical` in the `propTypes` so the option appears in the Documentation.