### PR TITLE
feat(Icon): add support for custom width/height

### DIFF
--- a/packages/axiom-components/src/Icon/Icon.js
+++ b/packages/axiom-components/src/Icon/Icon.js
@@ -13,6 +13,8 @@ export default class Icon extends Component {
      * Inline styling that allows the Icon to placed next to other inline
      * elements or text.
      */
+    /** Height of icon (with unit). */
+    height: PropTypes.string,
     inline: PropTypes.bool,
     /** Name of the icon that will be displayed */
     name: PropTypes.oneOf([
@@ -110,12 +112,14 @@ export default class Icon extends Component {
       'warning',
       'warning-circle',
     ]).isRequired,
-    /** Size of icon (with unit) */
+    /** Size of icon (with unit). Not used when height or width is provided */
     size: PropTypes.string,
     /** Spacing applied to the left of the Icon. Must be used with the inline property */
     spaceLeft: PropTypes.oneOf(['x1', 'x2']),
     /** Spacing applied to the right of the Icon. Must be used with the inline property */
     spaceRight: PropTypes.oneOf(['x1', 'x2']),
+    /** Width of icon (with unit). */
+    width: PropTypes.string,
   };
 
   static defaultProps = {
@@ -123,8 +127,11 @@ export default class Icon extends Component {
   };
 
   render() {
-    const { className, inline, name, size, spaceLeft, spaceRight, ...rest } = this.props;
-    const style = { width: size, height: size };
+    const { className, inline, name, size, width, height, spaceLeft, spaceRight, ...rest } = this.props;
+    const style = (height || width) ?
+      { width, height } :
+      { width: size, height: size };
+
     const classes = classnames(className, 'ax-icon', `ax-icon--${name}`, {
       'ax-icon--inline': inline,
       [`ax-icon--space-left-${spaceLeft}`]: spaceLeft,

--- a/packages/axiom-components/src/Icon/Icon.test.js
+++ b/packages/axiom-components/src/Icon/Icon.test.js
@@ -25,4 +25,16 @@ describe('Icon', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders with custom width', () => {
+    const component = getComponent({ width: '4rem' });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with custom height', () => {
+    const component = getComponent({ height: '4rem' });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/axiom-components/src/Icon/__snapshots__/Icon.test.js.snap
+++ b/packages/axiom-components/src/Icon/__snapshots__/Icon.test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Icon renders with custom height 1`] = `
+<svg
+  className="ax-icon ax-icon--twitter"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "",
+    }
+  }
+  style={
+    Object {
+      "height": "4rem",
+      "width": undefined,
+    }
+  }
+  viewBox="0 0 16 16"
+/>
+`;
+
 exports[`Icon renders with custom size 1`] = `
 <svg
   className="ax-icon ax-icon--twitter"
@@ -11,6 +29,24 @@ exports[`Icon renders with custom size 1`] = `
   style={
     Object {
       "height": "4rem",
+      "width": "4rem",
+    }
+  }
+  viewBox="0 0 16 16"
+/>
+`;
+
+exports[`Icon renders with custom width 1`] = `
+<svg
+  className="ax-icon ax-icon--twitter"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "",
+    }
+  }
+  style={
+    Object {
+      "height": undefined,
       "width": "4rem",
     }
   }


### PR DESCRIPTION
Add the option to set the `height` and/or `width` instead of just `size` for an icon. 

Useful for non-square icons like the iris icon added in #726 