### PR TITLE
refactor: updates luxon and removes defunct workaround

### DIFF
--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -15,7 +15,7 @@
     "classnames": "^2.2.6",
     "element-closest": "^2.0.2",
     "lodash.omit": "^4.5.0",
-    "luxon": "^1.3.1",
+    "luxon": "^1.12.0",
     "popper.js": "^1.12.5",
     "prop-types": "^15.6.0",
     "react": "^16.4.1",

--- a/packages/axiom-components/src/DurationPicker/DurationPicker.js
+++ b/packages/axiom-components/src/DurationPicker/DurationPicker.js
@@ -15,27 +15,6 @@ import TextInputIcon from '../Form/TextInputIcon';
 
 const validTimeUnits = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'];
 
-/**
- * This should be removed in favour of duration.toISO(),
- * only after the following PR has been merged
- * https://github.com/moment/luxon/pull/470
- */
-const formatDuration = (duration) => {
-  const filteredTimeUnits = []
-    .concat(validTimeUnits)
-    .reverse()
-    .filter((timeUnit) => duration.values[timeUnit]);
-  const timeDesignatorTimeUnits = validTimeUnits.slice(0, 3);
-  const timeDesignatorIndex = filteredTimeUnits.findIndex((timeUnit) => timeDesignatorTimeUnits.includes(timeUnit));
-
-  return filteredTimeUnits.reduce((memo, timeUnit, index) => {
-    const timeDesignator = index === timeDesignatorIndex ? 'T' : '';
-    const value = duration.values[timeUnit];
-    const designator = timeUnit.slice(0, 1).toUpperCase();
-    return `${memo}${timeDesignator}${value}${designator}`;
-  }, 'P');
-};
-
 const getStateFromIsoDurationValue = (value) => {
   const duration = Duration.fromISO(value);
 
@@ -66,7 +45,7 @@ const getIsoDurationValueFromState = (state) => {
     [selectedUnit]: selectedValue,
   });
 
-  return formatDuration(duration);
+  return duration.toISO();
 };
 
 const formatTimeUnit = (timeUnit) => {

--- a/packages/axiom-formatting/package.json
+++ b/packages/axiom-formatting/package.json
@@ -8,6 +8,6 @@
     "access": "public"
   },
   "dependencies": {
-    "luxon": "^1.3.1"
+    "luxon": "^1.12.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7369,10 +7369,10 @@ lru-cache@^4.1.2, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luxon@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.3.1.tgz#d9073c578738cebbf22a5f9d64eca7719e706072"
-  integrity sha512-GnX4PVEfDcTZT3xDQhm2jvEyZTxfi2b0gOmkJuwrrggA1b46e8ZshmPYePA6gdAT6mvvOxYnGFfb3iE9ZsWn9g==
+luxon@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.12.0.tgz#d02d53c8d8aaebe6b4c00ba1ce1be3913546b2e7"
+  integrity sha512-enPnPIHd5ZnZT0vpj9Xv8aq4j0yueAkhnh4xUKUHpqlgSm1r/8s6xTMjfyp2ugOWP7zivqJqgVTkW+rpHed61w==
 
 macaddress@^0.2.8:
   version "0.2.8"


### PR DESCRIPTION
Removed a workaround, as a result of Luxon being patched here https://github.com/moment/luxon/pull/470