### PR TITLE
chore(ImageFallback): Remove deprecated lifecycle method

### DIFF
--- a/packages/axiom-components/src/Image/ImageFallback.js
+++ b/packages/axiom-components/src/Image/ImageFallback.js
@@ -49,7 +49,7 @@ export default class ImageFallback extends Component {
     }
   }
 
-  componentWillUpdate(nextProps) {
+  componentDidUpdate(nextProps) {
     if (this.image && nextProps.src !== this.props.src) {
       this.image.src = nextProps.src;
     }


### PR DESCRIPTION
By wrapping App in `<React.StrictMode>` you can see unsafe/deprecated lifecycle methods used in Axiom and it's deps.

There is only one used in Axiom it's self. That is updated in this PR. The others are in `react-router-dom` & `react-router` but as these are only used for the docs routing and likely to change i've not upgraded the deps here.