### PR TITLE
 chore(Dropdown): Update Dropdown components to use new context API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-hot-loader": "^3.1.3",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-test-renderer": "^16.0.0",
+    "react-test-renderer": "^16.8.6",
     "static-site-generator-webpack-plugin": "^3.4.1",
     "style-loader": "^0.13.1",
     "stylelint": "^7.9.0",

--- a/packages/axiom-components/src/DatePicker/DatePickerControls.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerControls.js
@@ -5,6 +5,7 @@ import Button from '../Button/Button';
 import ButtonGroup from '../Button/ButtonGroup';
 import Grid from '../Grid/Grid';
 import GridCell from '../Grid/GridCell';
+import DropdownReactContext from '../Dropdown/DropdownReactContext';
 
 export default class DatePickerControls extends Component {
   static propTypes = {
@@ -17,9 +18,7 @@ export default class DatePickerControls extends Component {
     view: PropTypes.string.isRequired,
   };
 
-  static contextTypes = {
-    closeDropdown: PropTypes.func.isRequired,
-  };
+  static contextType = DropdownReactContext;
 
   constructor(props) {
     super(props);

--- a/packages/axiom-components/src/Dropdown/Dropdown.js
+++ b/packages/axiom-components/src/Dropdown/Dropdown.js
@@ -6,6 +6,7 @@ import PositionSource from '../Position/PositionSource';
 import PositionTarget from '../Position/PositionTarget';
 import { DropdownSourceRef } from './DropdownSource';
 import { DropdownTargetRef } from './DropdownTarget';
+import DropdownReactContext from './DropdownReactContext';
 import ReactDOM from 'react-dom';
 
 /* eslint-disable react/no-find-dom-node */
@@ -46,13 +47,6 @@ export default class Dropdown extends Component {
     withMask: PropTypes.bool,
   };
 
-  static childContextTypes = {
-    closeDropdown: PropTypes.func.isRequired,
-    openDropdown: PropTypes.func.isRequired,
-    toggleDropdown: PropTypes.func.isRequired,
-    dropdownRef: PropTypes.func.isRequired,
-  };
-
   static defaultProps = {
     enabled: true,
     position: 'bottom',
@@ -65,7 +59,7 @@ export default class Dropdown extends Component {
     this.state = { isVisible: false };
   }
 
-  getChildContext() {
+  getContext() {
     return {
       closeDropdown: () => this.close(),
       openDropdown: () => this.open(),
@@ -102,18 +96,20 @@ export default class Dropdown extends Component {
     const { isVisible } = this.state;
 
     return (
-      <Position
-          { ...rest }
-          isVisible={ isVisible }
-          offset={ offset }
-          onMaskClick={ withMask ? () => this.close() : null }
-          position={ position }
-          ref={ (el) => this.el = ReactDOM.findDOMNode(el) }>
-        <PositionTarget>
-          { React.cloneElement(findComponent(children, DropdownTargetRef)) }
-        </PositionTarget>
-        <PositionSource>{ findComponent(children, DropdownSourceRef) }</PositionSource>
-      </Position>
+      <DropdownReactContext.Provider value={ this.getContext() }>
+        <Position
+            { ...rest }
+            isVisible={ isVisible }
+            offset={ offset }
+            onMaskClick={ withMask ? () => this.close() : null }
+            position={ position }
+            ref={ (el) => this.el = ReactDOM.findDOMNode(el) }>
+          <PositionTarget>
+            { React.cloneElement(findComponent(children, DropdownTargetRef)) }
+          </PositionTarget>
+          <PositionSource>{ findComponent(children, DropdownSourceRef) }</PositionSource>
+        </Position>
+      </DropdownReactContext.Provider>
     );
   }
 }

--- a/packages/axiom-components/src/Dropdown/DropdownContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContext.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import omit from 'lodash.omit';
 import Context from '../Context/Context';
 import { contextMenuItemSelector } from '../Context/ContextMenuItem';
+import DropdownReactContext from './DropdownReactContext';
 
 if (typeof window !== 'undefined') {
   require('element-closest');
@@ -36,10 +37,7 @@ export default class DropdownContext extends Component {
     width: '14.5rem',
   };
 
-  static contextTypes = {
-    closeDropdown: PropTypes.func.isRequired,
-    dropdownRef: PropTypes.func.isRequired,
-  };
+  static contextType = DropdownReactContext;
 
   constructor(props) {
     super(props);

--- a/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
+++ b/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import omit from 'lodash.omit';
 import ContextMenuItem from '../Context/ContextMenuItem';
+import DropdownReactContext from './DropdownReactContext';
 
 export default class DropdownMenuItem extends Component {
   static propTypes = {
@@ -26,9 +27,7 @@ export default class DropdownMenuItem extends Component {
     selected: PropTypes.bool,
   };
 
-  static contextTypes = {
-    closeDropdown: PropTypes.func.isRequired,
-  };
+  static contextType = DropdownReactContext;
 
   constructor(props) {
     super(props);

--- a/packages/axiom-components/src/Dropdown/DropdownReactContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownReactContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext();

--- a/packages/axiom-components/src/Dropdown/DropdownSource.js
+++ b/packages/axiom-components/src/Dropdown/DropdownSource.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { Component, cloneElement } from 'react';
+import DropdownReactContext from './DropdownReactContext';
 
 export const DropdownSourceRef = 'DropdownSource';
 
@@ -8,9 +9,7 @@ export default class DropdownSource extends Component {
     children: PropTypes.node.isRequired,
   };
 
-  static contextTypes = {
-    closeDropdown: PropTypes.func.isRequired,
-  }
+  static contextType = DropdownReactContext;
 
   static typeRef = DropdownSourceRef;
 

--- a/packages/axiom-components/src/Dropdown/DropdownTarget.js
+++ b/packages/axiom-components/src/Dropdown/DropdownTarget.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { Component, cloneElement } from 'react';
+import DropdownReactContext from './DropdownReactContext';
 
 export const DropdownTargetRef = 'DropdownTarget';
 
@@ -8,10 +9,7 @@ export default class DropdownTarget extends Component {
     children: PropTypes.node.isRequired,
   };
 
-  static contextTypes = {
-    openDropdown: PropTypes.func.isRequired,
-    toggleDropdown: PropTypes.func.isRequired,
-  };
+  static contextType = DropdownReactContext;
 
   static typeRef = DropdownTargetRef;
 

--- a/packages/axiom-components/src/Select/SelectInput.js
+++ b/packages/axiom-components/src/Select/SelectInput.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import TextInput from '../Form/TextInput';
 import TextInputIcon from '../Form/TextInputIcon';
+import DropdownReactContext from '../Dropdown/DropdownReactContext';
 
 export default class SelectInput extends Component {
   static propTypes = {
@@ -10,10 +11,7 @@ export default class SelectInput extends Component {
     onFocus: PropTypes.func,
   };
 
-  static contextTypes = {
-    closeDropdown: PropTypes.func,
-    openDropdown: PropTypes.func,
-  };
+  static contextType = DropdownReactContext;
 
   constructor(props) {
     super(props);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6717,7 +6717,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -7332,6 +7332,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -9721,6 +9728,15 @@ prop-types@^15.5.8:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -10009,6 +10025,11 @@ react-hot-loader@^3.1.3:
     redbox-react "^1.3.6"
     source-map "^0.6.1"
 
+react-is@^16.8.1, react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
@@ -10051,7 +10072,7 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
+react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   integrity sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==
@@ -10059,6 +10080,16 @@ react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-test-renderer@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.8.6.tgz#188d8029b8c39c786f998aa3efd3ffe7642d5ba1"
+  integrity sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.13.6"
 
 react-transition-group@^2.3.0:
   version "2.3.0"
@@ -10791,6 +10822,14 @@ saxes@^3.1.5:
   integrity sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==
   dependencies:
     xmlchars "^1.3.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 schema-utils@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Legacy context API has a bug, was never probably supported and has performance issues. We use this API in several components the upgrade is pretty simple but this PR just deals with the Dropdown component. I will update the rest of the components using the same pattern in a 2nd PR.

Further Reading.
reactjs.org/docs/legacy-context.html
https://kentcdodds.com/blog/migrating-to-reacts-new-context-api