### PR TITLE
AX-135 - Dark Tooltips

### DIFF
--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -33,10 +33,35 @@
   position: relative;
   overflow: hidden;
 
-  @nest .ax-context--success & { background-color: var(--color-ui-success); }
-  @nest .ax-context--warning & { background-color: var(--color-ui-warning); }
-  @nest .ax-context--error & { background-color: var(--color-ui-error); }
-  @nest .ax-context--info & { background-color: var(--color-ui-info); }
+  @nest .ax-context--success & {
+    background-color: var(--color-ui-success);
+    color: var(--color-ui-white-noise);
+  }
+
+  @nest .ax-context--warning & {
+    background-color: var(--color-ui-warning);
+    color: var(--color-ui-carbon);
+  }
+
+  @nest .ax-context--error & {
+    background-color: var(--color-ui-error);
+    color: var(--color-ui-white-noise);
+  }
+
+  @nest .ax-context--info & {
+    background-color: var(--color-ui-info);
+    color: var(--color-ui-white-noise);
+  }
+
+  @nest .ax-context--carbon & {
+    background-color: var(--color-ui-carbon);
+    color: var(--color-ui-white-noise);
+  }
+
+  @nest .ax-context--white & {
+    background-color: var(--color-ui-white);
+    color: var(--color-ui-carbon);
+  }
 }
 
 .ax-context-content--padding-horizontal-tiny {

--- a/packages/axiom-components/src/Context/Context.js
+++ b/packages/axiom-components/src/Context/Context.js
@@ -9,7 +9,7 @@ export default class Context extends Component {
   static propTypes = {
     arrowRef: PropTypes.func,
     children: PropTypes.node,
-    color: PropTypes.oneOf(['success', 'warning', 'error', 'info']),
+    color: PropTypes.oneOf(['success', 'warning', 'error', 'info', 'carbon', 'white']),
     maxHeight: PropTypes.string,
     position: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
     width: PropTypes.string,

--- a/packages/axiom-components/src/Tip/Tip.css
+++ b/packages/axiom-components/src/Tip/Tip.css
@@ -56,6 +56,8 @@
   @nest .ax-tip--shade-2 & { background-color: var(--color-theme-background--shade-2); }
   @nest .ax-tip--shade-3 & { background-color: var(--color-theme-background--shade-3); }
   @nest .ax-tip--shade-4 & { background-color: var(--color-theme-background--shade-4); }
+  @nest .ax-tip--carbon & { background-color: var(--color-ui-carbon); }
+  @nest .ax-tip--white & { background-color: var(--color-ui-white); }
 
   @nest .ax-tip--shadow & {
     box-shadow: var(--drop-shadow-theme-border), var(--drop-shadow-theme-elevation--x2);

--- a/packages/axiom-components/src/Tip/Tip.js
+++ b/packages/axiom-components/src/Tip/Tip.js
@@ -11,7 +11,7 @@ export default class Tip extends Component {
     /** The content on which the tip should be placed. */
     children: PropTypes.node,
     /** Background color for the tip */
-    color: PropTypes.oneOf(['success', 'warning', 'error', 'info', 'shade-1', 'shade-2', 'shade-3', 'shade-4']),
+    color: PropTypes.oneOf(['success', 'warning', 'error', 'info', 'shade-1', 'shade-2', 'shade-3', 'shade-4', 'carbon', 'white']),
     /** The direction at which the Tip should be pointing. The directions are opposite, for example,
      * if the arrow should be placed on the 'left', its direction prop should be 'right'. The same applies for 'top' and 'bottom'. */
     direction: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),

--- a/packages/axiom-components/src/Tooltip/TooltipContext.js
+++ b/packages/axiom-components/src/Tooltip/TooltipContext.js
@@ -4,7 +4,7 @@ import Context from '../Context/Context';
 
 export default class TooltipContext extends Component {
   static propTypes = {
-    color: PropTypes.oneOf(['success', 'warning', 'error', 'info']),
+    color: PropTypes.oneOf(['success', 'warning', 'error', 'info', 'carbon', 'white']),
   }
   render() {
 

--- a/site/components/Documentation/Resources/Components/Tooltip.js
+++ b/site/components/Documentation/Resources/Components/Tooltip.js
@@ -34,7 +34,7 @@ export default class Documentation extends Component {
                   </DataPoints>
                 </TooltipTarget>
 
-                <TooltipSource theme="night" width="auto">
+                <TooltipSource width="auto">
                   <TooltipContext>
                     <TooltipContent size="tiny">50%</TooltipContent>
                   </TooltipContext>
@@ -51,7 +51,7 @@ export default class Documentation extends Component {
                   </DataPoints>
                 </TooltipTarget>
 
-                <TooltipSource theme="night" width="auto">
+                <TooltipSource width="auto">
                   <TooltipContext>
                     <TooltipContent>Tooltip content</TooltipContent>
                   </TooltipContext>


### PR DESCRIPTION
https://office.brandwatch.com/jira/browse/AX-135

This PR addresses a few things to do with Tooltips

**Inaccurate Documentation**
The documentation for Tooltips had the `TooltipSource` component hard-coded to have the `theme='night'` prop, which is unrepresentative of how implementation of ToolTips may have occurred within other projects. This has been removed and now shows how Tooltips actually work if just used exactly as they appear.

I would propose in the new documentation that we write using DocZ that gotchas like this are covered in a possible `use cases` section, with explanations as to why you need to give `TooltipSource` a theme in the first place.

**Font Color**
After removing the hard-coded theme from the documentation, it was easier to see another issue that was hidden beforehand where the font would take on the colour of the parent theme, regardless of the colour of the background. This could lead to badly contrasting text-color on background-color pairs.

I spoke to Aliyah about what font colours should appear on particular background and ensured that these were permanently set in the CSS.

**Tooltip Colours**
The meat of the original ticket! This PR adds two new colours that can be explicitly chosen by the user: `Carbon` and `White`. This mimics the way tooltips would appear if used with a dark or night theme and allows a user to override the theme settings with a forced colour where appropriate for designs