### PR TITLE
feat(Chip): Add chip component

### DIFF
--- a/packages/axiom-components/src/Chip/Chip.css
+++ b/packages/axiom-components/src/Chip/Chip.css
@@ -5,7 +5,6 @@
   margin-right: var(--cmp-inline-spacing);
   margin-bottom: var(--cmp-inline-spacing);
   padding: 0;
-  float: left;
   outline: 0;
   border-width: var(--component-border-width);
   border-style: solid;

--- a/packages/axiom-components/src/Chip/Chip.css
+++ b/packages/axiom-components/src/Chip/Chip.css
@@ -1,0 +1,116 @@
+.ax-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-right: var(--cmp-inline-spacing);
+  margin-bottom: var(--cmp-inline-spacing);
+  padding: 0;
+  float: left;
+  outline: 0;
+  border-width: var(--component-border-width);
+  border-style: solid;
+  border-radius: var(--component-border-radius-huge);
+  border-color: transparent;
+  background-color: var(--color-ui-white-noise);
+  color: var(--color-ui-carbon);
+  letter-spacing: var(--letter-spacing-loose);
+  text-align: center;
+  line-height: var(--component-line-height);
+  white-space: nowrap;
+  vertical-align: middle;
+  transition-property: background-color, border-color, color;
+  transition-duration: var(--transition-time-base);
+  transition-timing-function: var(--transition-function);
+
+  &:hover {
+    background-color: var(--color-ui-white-noise--dark);
+    cursor: pointer;
+  }
+
+  &[disabled],
+  &[disabled]:hover,
+  &[disabled]:active {
+    cursor: default;
+  }
+
+  &[disabled]:hover {
+    background-color: var(--color-ui-white-noise);
+  }
+}
+
+.ax-chip-metric {
+  margin-right: var(--spacing-grid-size--x1);
+  margin-left: -var(--spacing-grid-size--x1);
+  color: var(--color-theme-text--subtle);
+}
+
+.ax-chip-metric--light {
+  color: var(--color-ui-white);
+}
+
+.ax-chip--active {
+  background-color: var(--color-ui-white);
+  color: var(--color-ui-carbon);
+
+  &:hover {
+    background-color: var(--color-ui-white);
+  }
+}
+
+.ax-chip--active.ax-chip-color--accent {
+  background-color: var(--color-ui-accent);
+  color: var(--color-ui-white);
+
+  &:hover {
+    background-color: var(--color-ui-accent--hover);
+  }
+}
+
+.ax-chip--active.ax-chip-color--highlight { border-color: var(--color-product-highlight); }
+.ax-chip--active.ax-chip-color--success { border-color: var(--color-product-success); }
+.ax-chip--active.ax-chip-color--error { border-color: var(--color-product-error); }
+.ax-chip--active.ax-chip-color--forbidden-planet { border-color: var(--color-product-forbidden-planet); }
+.ax-chip--active.ax-chip-color--tiny-clanger { border-color: var(--color-product-tiny-clanger); }
+.ax-chip--active.ax-chip-color--critical-mass { border-color: var(--color-product-critical-mass); }
+.ax-chip--active.ax-chip-color--fantastic-voyage { border-color: var(--color-product-fantastic-voyage); }
+.ax-chip--active.ax-chip-color--paradise-lost { border-color: var(--color-product-paradise-lost); }
+.ax-chip--active.ax-chip-color--serene-sea { border-color: var(--color-product-serene-sea); }
+.ax-chip--active.ax-chip-color--event-horizon { border-color: var(--color-product-event-horizon); }
+.ax-chip--active.ax-chip-color--electric-dreams { border-color: var(--color-product-electric-dreams); }
+.ax-chip--active.ax-chip-color--outer-limits { border-color: var(--color-product-outer-limits); }
+.ax-chip--active.ax-chip-color--giant-leap { border-color: var(--color-product-giant-leap); }
+.ax-chip--active.ax-chip-color--moon-lagoon { border-color: var(--color-product-moon-lagoon); }
+.ax-chip--active.ax-chip-color--space-invader { border-color: var(--color-product-space-invader); }
+.ax-chip--active.ax-chip-color--extraterrestrial { border-color: var(--color-product-extraterrestrial); }
+.ax-chip--active.ax-chip-color--terra-form { border-color: var(--color-product-terra-form); }
+.ax-chip--active.ax-chip-color--primeval-soup { border-color: var(--color-product-primeval-soup); }
+.ax-chip--active.ax-chip-color--future-shock { border-color: var(--color-product-future-shock); }
+.ax-chip--active.ax-chip-color--sun-maker { border-color: var(--color-product-sun-maker); }
+.ax-chip--active.ax-chip-color--new-horizon { border-color: var(--color-product-new-horizon); }
+.ax-chip--active.ax-chip-color--blast-off { border-color: var(--color-product-blast-off); }
+.ax-chip--active.ax-chip-color--crash-course { border-color: var(--color-product-crash-course); }
+.ax-chip--active.ax-chip-color--solar-rust { border-color: var(--color-product-solar-rust); }
+.ax-chip--active.ax-chip-color--ground-control { border-color: var(--color-product-ground-control); }
+.ax-chip--active.ax-chip-color--space-oddity { border-color: var(--color-product-space-oddity); }
+.ax-chip--active.ax-chip-color--rocky-planet { border-color: var(--color-product-rocky-planet); }
+.ax-chip--active.ax-chip-color--deep-thought { border-color: var(--color-product-deep-thought); }
+.ax-chip--active.ax-chip-color--luna-dust { border-color: var(--color-product-luna-dust); }
+
+.ax-chip-label {
+  margin: 0 var(--spacing-grid-size--x2) 0 var(--spacing-grid-size--x2);
+}
+
+.ax-chip--small {
+  padding: var(--component-padding-vertical-small) var(--component-padding-horizontal-small);
+  font-size: var(--font-size-small);
+}
+
+.ax-chip--medium {
+  padding: var(--component-padding-vertical-medium) var(--component-padding-horizontal-medium);
+  font-size: var(--font-size-medium);
+}
+
+.ax-chip--large {
+  padding: var(--component-padding-vertical-large) var(--component-padding-horizontal-large);
+  font-size: var(--font-size-large);
+}

--- a/packages/axiom-components/src/Chip/Chip.css
+++ b/packages/axiom-components/src/Chip/Chip.css
@@ -48,52 +48,17 @@
 }
 
 .ax-chip--active {
-  background-color: var(--color-ui-white);
-  color: var(--color-ui-carbon);
-
-  &:hover {
-    background-color: var(--color-ui-white);
-  }
-}
-
-.ax-chip--active.ax-chip-color--accent {
   background-color: var(--color-ui-accent);
   color: var(--color-ui-white);
 
   &:hover {
     background-color: var(--color-ui-accent--hover);
   }
-}
 
-.ax-chip--active.ax-chip-color--highlight { border-color: var(--color-product-highlight); }
-.ax-chip--active.ax-chip-color--success { border-color: var(--color-product-success); }
-.ax-chip--active.ax-chip-color--error { border-color: var(--color-product-error); }
-.ax-chip--active.ax-chip-color--forbidden-planet { border-color: var(--color-product-forbidden-planet); }
-.ax-chip--active.ax-chip-color--tiny-clanger { border-color: var(--color-product-tiny-clanger); }
-.ax-chip--active.ax-chip-color--critical-mass { border-color: var(--color-product-critical-mass); }
-.ax-chip--active.ax-chip-color--fantastic-voyage { border-color: var(--color-product-fantastic-voyage); }
-.ax-chip--active.ax-chip-color--paradise-lost { border-color: var(--color-product-paradise-lost); }
-.ax-chip--active.ax-chip-color--serene-sea { border-color: var(--color-product-serene-sea); }
-.ax-chip--active.ax-chip-color--event-horizon { border-color: var(--color-product-event-horizon); }
-.ax-chip--active.ax-chip-color--electric-dreams { border-color: var(--color-product-electric-dreams); }
-.ax-chip--active.ax-chip-color--outer-limits { border-color: var(--color-product-outer-limits); }
-.ax-chip--active.ax-chip-color--giant-leap { border-color: var(--color-product-giant-leap); }
-.ax-chip--active.ax-chip-color--moon-lagoon { border-color: var(--color-product-moon-lagoon); }
-.ax-chip--active.ax-chip-color--space-invader { border-color: var(--color-product-space-invader); }
-.ax-chip--active.ax-chip-color--extraterrestrial { border-color: var(--color-product-extraterrestrial); }
-.ax-chip--active.ax-chip-color--terra-form { border-color: var(--color-product-terra-form); }
-.ax-chip--active.ax-chip-color--primeval-soup { border-color: var(--color-product-primeval-soup); }
-.ax-chip--active.ax-chip-color--future-shock { border-color: var(--color-product-future-shock); }
-.ax-chip--active.ax-chip-color--sun-maker { border-color: var(--color-product-sun-maker); }
-.ax-chip--active.ax-chip-color--new-horizon { border-color: var(--color-product-new-horizon); }
-.ax-chip--active.ax-chip-color--blast-off { border-color: var(--color-product-blast-off); }
-.ax-chip--active.ax-chip-color--crash-course { border-color: var(--color-product-crash-course); }
-.ax-chip--active.ax-chip-color--solar-rust { border-color: var(--color-product-solar-rust); }
-.ax-chip--active.ax-chip-color--ground-control { border-color: var(--color-product-ground-control); }
-.ax-chip--active.ax-chip-color--space-oddity { border-color: var(--color-product-space-oddity); }
-.ax-chip--active.ax-chip-color--rocky-planet { border-color: var(--color-product-rocky-planet); }
-.ax-chip--active.ax-chip-color--deep-thought { border-color: var(--color-product-deep-thought); }
-.ax-chip--active.ax-chip-color--luna-dust { border-color: var(--color-product-luna-dust); }
+  &[disabled]:hover {
+    background-color: var(--color-ui-accent);
+  }
+}
 
 .ax-chip-label {
   margin: 0 var(--spacing-grid-size--x2) 0 var(--spacing-grid-size--x2);

--- a/packages/axiom-components/src/Chip/Chip.js
+++ b/packages/axiom-components/src/Chip/Chip.js
@@ -9,39 +9,6 @@ export default class Chip extends Component {
   static propTypes = {
     /** Apply active styling */
     active: PropTypes.bool,
-    /** Colour of the Chip when active */
-    activeColor: PropTypes.oneOf([
-      'accent',
-      'highlight',
-      'success',
-      'error',
-      'forbidden-planet',
-      'tiny-clanger',
-      'critical-mass',
-      'fantastic-voyage',
-      'paradise-lost',
-      'serene-sea',
-      'event-horizon',
-      'electric-dreams',
-      'outer-limits',
-      'giant-leap',
-      'moon-lagoon',
-      'space-invader',
-      'extraterrestrial',
-      'terra-form',
-      'primeval-soup',
-      'future-shock',
-      'sun-maker',
-      'new-horizon',
-      'blast-off',
-      'crash-course',
-      'solar-rust',
-      'ground-control',
-      'space-oddity',
-      'rocky-planet',
-      'deep-thought',
-      'luna-dust',
-    ]).isRequired,
     /** Content for chip */
     children: PropTypes.node.isRequired,
     /** Disable interaction behaviour */
@@ -57,7 +24,6 @@ export default class Chip extends Component {
   };
 
   static defaultProps = {
-    activeColor: 'accent',
     size: 'medium',
   };
 
@@ -65,7 +31,6 @@ export default class Chip extends Component {
 
     const {
       active,
-      activeColor,
       children,
       disabled,
       leftIcon,
@@ -77,24 +42,19 @@ export default class Chip extends Component {
 
     const classes = classnames('ax-chip',
       `ax-chip--${size}`,
-      `ax-chip-color--${activeColor}`,
       { 'ax-chip--active': active },
     );
 
-    const iconClasses = classnames('ax-chip-icon',
-      `ax-text--color-${activeColor}`
-    );
-
     const metricClasses = classnames('ax-chip-metric',
-      { 'ax-chip-metric--light': active && activeColor == 'accent' }
+      { 'ax-chip-metric--light': active }
     );
 
     return (
       <Base className={ classes } disabled={ disabled } { ...rest }>
-        { leftIcon && (<Icon className={ iconClasses } name={ leftIcon } /> ) }
+        { leftIcon && (<Icon className={ 'ax-chip-icon' } name={ leftIcon } /> ) }
         <Base className="ax-chip-label">{ children }</Base>
         { metric && (<Base className={ metricClasses }> { metric }</Base>) }
-        { rightIcon && (<Icon className={ iconClasses } name={ rightIcon } />) }
+        { rightIcon && (<Icon className={ 'ax-chip-icon' } name={ rightIcon } />) }
       </Base>
     );
   }

--- a/packages/axiom-components/src/Chip/Chip.js
+++ b/packages/axiom-components/src/Chip/Chip.js
@@ -1,0 +1,102 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Base from '../Base/Base';
+import Icon from '../Icon/Icon';
+import classnames from 'classnames';
+import './Chip.css';
+
+export default class Chip extends Component {
+  static propTypes = {
+    /** Apply active styling */
+    active: PropTypes.bool,
+    /** Colour of the Chip when active */
+    activeColor: PropTypes.oneOf([
+      'accent',
+      'highlight',
+      'success',
+      'error',
+      'forbidden-planet',
+      'tiny-clanger',
+      'critical-mass',
+      'fantastic-voyage',
+      'paradise-lost',
+      'serene-sea',
+      'event-horizon',
+      'electric-dreams',
+      'outer-limits',
+      'giant-leap',
+      'moon-lagoon',
+      'space-invader',
+      'extraterrestrial',
+      'terra-form',
+      'primeval-soup',
+      'future-shock',
+      'sun-maker',
+      'new-horizon',
+      'blast-off',
+      'crash-course',
+      'solar-rust',
+      'ground-control',
+      'space-oddity',
+      'rocky-planet',
+      'deep-thought',
+      'luna-dust',
+    ]).isRequired,
+    /** Content for chip */
+    children: PropTypes.node.isRequired,
+    /** Disable interaction behaviour */
+    disabled: PropTypes.bool,
+    /** Name of the Icon located to the left of the main content */
+    leftIcon: PropTypes.string,
+    /** Metric content */
+    metric: PropTypes.string,
+    /** Name of the Icon located to the right of the main content or metric */
+    rightIcon: PropTypes.string,
+    /** Size of the chip */
+    size: PropTypes.oneOf(['small', 'medium', 'large', 'huge']),
+  };
+
+  static defaultProps = {
+    activeColor: 'accent',
+    borderStyle: 'solid',
+    size: 'medium',
+  };
+
+  render() {
+
+    const {
+      active,
+      activeColor,
+      children,
+      disabled,
+      leftIcon,
+      metric,
+      rightIcon,
+      size,
+      ...rest
+    } = this.props;
+
+    const classes = classnames('ax-chip',
+      `ax-chip--${size}`,
+      `ax-chip-color--${activeColor}`,
+      { 'ax-chip--active': active },
+    );
+
+    const iconClasses = classnames('ax-chip-icon',
+      `ax-text--color-${activeColor}`
+    );
+
+    const metricClasses = classnames('ax-chip-metric',
+      { 'ax-chip-metric--light': activeColor == 'accent' }
+    );
+
+    return (
+      <Base className={ classes } disabled={ disabled } { ...rest }>
+        { leftIcon && (<Icon className={ iconClasses } name={ leftIcon } /> ) }
+        <Base className="ax-chip-label">{ children }</Base>
+        { metric && (<Base className={ metricClasses }> { metric }</Base>) }
+        { rightIcon && (<Icon className={ iconClasses } name={ rightIcon } />) }
+      </Base>
+    );
+  }
+}

--- a/packages/axiom-components/src/Chip/Chip.js
+++ b/packages/axiom-components/src/Chip/Chip.js
@@ -58,7 +58,6 @@ export default class Chip extends Component {
 
   static defaultProps = {
     activeColor: 'accent',
-    borderStyle: 'solid',
     size: 'medium',
   };
 
@@ -87,7 +86,7 @@ export default class Chip extends Component {
     );
 
     const metricClasses = classnames('ax-chip-metric',
-      { 'ax-chip-metric--light': activeColor == 'accent' }
+      { 'ax-chip-metric--light': active && activeColor == 'accent' }
     );
 
     return (

--- a/packages/axiom-components/src/Chip/ChipList.css
+++ b/packages/axiom-components/src/Chip/ChipList.css
@@ -1,0 +1,72 @@
+.ax-chiplist {
+  margin-top: var(--spacing-grid-size--x2);
+  margin-bottom: var(--spacing-grid-size--x2);
+  overflow: hidden;
+  &::after {
+    content: '';
+    display: table;
+    clear: both;
+  }
+}
+
+.ax-chiplist-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: var(--spacing-grid-size--x1);
+  float: left;
+  font-weight: var(--font-weight-bold);
+  line-height: var(--component-line-height);
+}
+
+.ax-chiplist--small,
+.ax-chiplist--medium,
+.ax-chiplist--large {
+  transition-property: max-height, opacity, margin;
+  transition-duration: var(--transition-time-slow);
+  transition-timing-function: var(--transition-function);
+}
+
+.ax-chiplist--small {
+  max-height: var(--component-total-line-height-small);
+}
+
+.ax-chiplist--medium {
+  max-height: var(--component-total-line-height-medium);
+}
+
+.ax-chiplist--large {
+  max-height: var(--component-total-line-height-large);
+}
+
+.ax-chiplist-label--small {
+  padding-top: var(--component-padding-vertical-small);
+  padding-right: var(--component-padding-horizontal-small);
+  padding-bottom: var(--component-padding-vertical-small);
+  padding-left: 0;
+  font-size: var(--font-size-small);
+}
+
+.ax-chiplist-label--medium {
+  padding-top: var(--component-padding-vertical-medium);
+  padding-right: var(--component-padding-horizontal-medium);
+  padding-bottom: var(--component-padding-vertical-medium);
+  padding-left: 0;
+  font-size: var(--font-size-medium);
+}
+
+.ax-chiplist-label--large {
+  padding-top: var(--component-padding-vertical-large);
+  padding-right: var(--component-padding-horizontal-large);
+  padding-bottom: var(--component-padding-vertical-large);
+  padding-left: 0;
+  font-size: var(--font-size-large);
+}
+
+.ax-chiplist--expanded {
+  max-height: var(--component-max-height);
+}
+
+.ax-chiplist--expandable {
+  cursor: pointer;
+}

--- a/packages/axiom-components/src/Chip/ChipList.css
+++ b/packages/axiom-components/src/Chip/ChipList.css
@@ -1,12 +1,9 @@
 .ax-chiplist {
+  display: flex;
+  flex-wrap: wrap;
   margin-top: var(--spacing-grid-size--x2);
   margin-bottom: var(--spacing-grid-size--x2);
   overflow: hidden;
-  &::after {
-    content: '';
-    display: table;
-    clear: both;
-  }
 }
 
 .ax-chiplist-label {
@@ -14,7 +11,7 @@
   align-items: center;
   justify-content: center;
   margin-right: var(--spacing-grid-size--x1);
-  float: left;
+  margin-bottom: var(--cmp-inline-spacing);
   font-weight: var(--font-weight-bold);
   line-height: var(--component-line-height);
 }

--- a/packages/axiom-components/src/Chip/ChipList.css
+++ b/packages/axiom-components/src/Chip/ChipList.css
@@ -20,7 +20,7 @@
 .ax-chiplist--medium,
 .ax-chiplist--large {
   transition-property: max-height, opacity, margin;
-  transition-duration: var(--transition-time-slow);
+  transition-duration: var(--transition-time-fast);
   transition-timing-function: var(--transition-function);
 }
 

--- a/packages/axiom-components/src/Chip/ChipList.js
+++ b/packages/axiom-components/src/Chip/ChipList.js
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Base from '../Base/Base';
+import Icon from '../Icon/Icon';
+import classnames from 'classnames';
+import './ChipList.css';
+
+export default class ChipList extends Component {
+  static propTypes = {
+    /** Array of Chip components */
+    children: PropTypes.node.isRequired,
+    /** Label of the List */
+    label: PropTypes.string,
+    /** Size of the chips in the chip list */
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
+  };
+
+  static defaultProps = {
+    size: 'medium',
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.chipList = React.createRef();
+    this.state = {
+      isExpanded: false,
+      isExpandable: false,
+    };
+  }
+
+  componentDidMount() {
+    const {
+      clientHeight,
+      scrollHeight,
+    } = this.chipList.current;
+
+    if (scrollHeight > (clientHeight * 2)) {
+      this.setState({ isExpandable: true });
+    }
+  }
+
+  handleExpand = () => {
+    if (this.state.isExpandable) {
+      this.setState({ isExpanded: !this.state.isExpanded });
+    }
+  }
+
+  render() {
+    const {
+      children,
+      label,
+      size,
+    } = this.props;
+
+    const {
+      isExpanded,
+      isExpandable,
+    } = this.state;
+
+    const childrenWithSize = React.Children.map(children, child => React.cloneElement(child, { size }));
+
+    const classes = classnames('ax-chiplist',
+      `ax-chiplist--${size}`,
+      { 'ax-chiplist--expanded': isExpanded }
+    );
+
+    const labelClasses = classnames('ax-chiplist-label',
+      `ax-chiplist-label--${size}`,
+      { 'ax-chiplist--expandable': isExpandable }
+    );
+
+    return (
+      <Base baseRef={ this.chipList } className={ classes }>
+
+        <div className={ labelClasses } onClick={ this.handleExpand }>
+          { label }
+          { isExpandable && (<Icon inline name={ isExpanded ? 'chevron-up' : 'chevron-down' } spaceLeft="x1" />) }
+        </div>
+
+        { childrenWithSize }
+
+      </Base>
+    );
+  }
+}

--- a/packages/axiom-components/src/index.js
+++ b/packages/axiom-components/src/index.js
@@ -30,6 +30,8 @@ export { default as CardImages } from './Card/CardImages';
 export { default as CardList } from './Card/CardList';
 export { default as CheckBox } from './Form/CheckBox';
 export { default as CheckBoxGroup } from './Form/CheckBoxGroup';
+export { default as Chip } from './Chip/Chip';
+export { default as ChipList } from './Chip/ChipList';
 export { default as Cloak } from './Cloak/Cloak';
 export { default as CloakContainer } from './Cloak/CloakContainer';
 export { default as ColorPicker } from './ColorPicker/ColorPicker';

--- a/packages/axiom-materials/src/sizing.css
+++ b/packages/axiom-materials/src/sizing.css
@@ -15,6 +15,10 @@
 
   --component-line-height: 1rem;
 
+  --component-total-line-height-small: calc(var(--component-line-height) + (var(--component-padding-vertical-small) * 2) + (var(--component-border-width-small) * 2));
+  --component-total-line-height-medium: calc(var(--component-line-height) + (var(--component-padding-vertical-medium) * 2) + (var(--component-border-width-medium) * 2));
+  --component-total-line-height-large: calc(var(--component-line-height) + (var(--component-padding-vertical-large) * 2) + (var(--component-border-width-large) * 2));
+
   --component-border-width-small: 0.0625rem;
   --component-border-width-medium: 0.0625rem;
   --component-border-width-large: 0.125rem;
@@ -23,6 +27,7 @@
 
   --component-border-radius: 0.1875rem;
   --component-border-radius-large: 0.5rem;
+  --component-border-radius-huge: 1.25rem;
 
   --component-padding-vertical-small: calc(var(--spacing-grid-size) - var(--component-border-width-small));
   --component-padding-vertical-medium: calc(calc(var(--spacing-grid-size) * 2) - var(--component-border-width-small));
@@ -68,5 +73,10 @@
    * Shared component variables.
    */
   --cmp-context-tip-edge-to-edge: 0.75rem;
+
+  /**
+   * Used for max-height of a topics container
+   */
+  --component-max-height: 62.5rem;
 }
 /* stylelint-enable */

--- a/site/components/Documentation/Resources/Components.js
+++ b/site/components/Documentation/Resources/Components.js
@@ -11,6 +11,7 @@ import Badge from './Components/Badge';
 import Base from './Components/Base';
 import Button from './Components/Button';
 import Card from './Components/Card';
+import Chip from './Components/Chip';
 import Cloak from './Components/Cloak';
 import ColorPicker from './Components/ColorPicker';
 import DataPicker from './Components/DataPicker';
@@ -103,6 +104,10 @@ export default class Documentation extends Component {
             id: 'card-graphic',
             name: 'Card Graphic',
             Component: CardGraphic,
+          }, {
+            id: 'chip',
+            name: 'Chip',
+            Component: Chip,
           }, {
             id: 'cloak',
             name: 'Cloak',

--- a/site/components/Documentation/Resources/Components/Chip.js
+++ b/site/components/Documentation/Resources/Components/Chip.js
@@ -25,16 +25,6 @@ export default class Documentation extends Component {
                 <Chip>Marcus Smart</Chip>
               </ChipList>
             </DocumentationShowCase>
-
-            <DocumentationShowCase centered>
-              <ChipList size={ 'small' }>
-                <Chip active activeColor={ 'event-horizon' } leftIcon={ 'dot' } metric={ '(99%)' }>Terry Rozier</Chip>
-                <Chip active activeColor={ 'blast-off' } leftIcon={ 'dot' } metric={ '(1%)' }>Marcus Morris</Chip>
-                <Chip active activeColor={ 'electric-dreams' } leftIcon={ 'dot' }>Daniel Theis</Chip>
-                <Chip activeColor={ 'future-shock' }>Aron Baynes</Chip>
-                <Chip>Marcus Smart</Chip>
-              </ChipList>
-            </DocumentationShowCase>
           </GridCell>
         </Grid>
 

--- a/site/components/Documentation/Resources/Components/Chip.js
+++ b/site/components/Documentation/Resources/Components/Chip.js
@@ -1,0 +1,48 @@
+import React, { Component } from 'react';
+import { Chip, ChipList, Grid, GridCell } from '@brandwatch/axiom-components';
+import {
+  DocumentationApi,
+  DocumentationContent,
+  DocumentationShowCase,
+} from '@brandwatch/axiom-documentation-viewer';
+
+export default class Documentation extends Component {
+  render() {
+    return (
+      <DocumentationContent>
+        <Grid>
+          <GridCell>
+            <DocumentationShowCase centered>
+              <ChipList label={ 'Topics' }>
+                <Chip>Kyrie Irving</Chip>
+                <Chip leftIcon={ 'tick' } metric={ '(65%)' }>Aron Baynes</Chip>
+                <Chip rightIcon={ 'cross' }>Jaylen Brown</Chip>
+                <Chip disabled>Jayson Tatum</Chip>
+                <Chip active metric={ '(1%)' } rightIcon={ 'cross' }>Al Horford</Chip>
+                <Chip>Terry Rozier</Chip>
+                <Chip>Marcus Morris</Chip>
+                <Chip>Gordon Hayward</Chip>
+                <Chip>Marcus Smart</Chip>
+              </ChipList>
+            </DocumentationShowCase>
+
+            <DocumentationShowCase centered>
+              <ChipList size={ 'small' }>
+                <Chip active activeColor={ 'event-horizon' } leftIcon={ 'dot' } metric={ '(99%)' }>Terry Rozier</Chip>
+                <Chip active activeColor={ 'blast-off' } leftIcon={ 'dot' } metric={ '(1%)' }>Marcus Morris</Chip>
+                <Chip active activeColor={ 'electric-dreams' } leftIcon={ 'dot' }>Daniel Theis</Chip>
+                <Chip activeColor={ 'future-shock' }>Aron Baynes</Chip>
+                <Chip>Marcus Smart</Chip>
+              </ChipList>
+            </DocumentationShowCase>
+          </GridCell>
+        </Grid>
+
+        <DocumentationApi components={ [
+          require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Chip/Chip'),
+          require('!!axiom-documentation-loader!@brandwatch/axiom-components/src/Chip/ChipList'),
+        ] } />
+      </DocumentationContent>
+    );
+  }
+}


### PR DESCRIPTION
A new chip component, wrapped in a auto-collapsing chip list component.  This was originally used for AD-4010, the topics in the details view work.  

Some examples of the different options:
![image](https://user-images.githubusercontent.com/7015464/56316841-58084080-6129-11e9-846e-e6f819c3c5e2.png)
![image](https://user-images.githubusercontent.com/7015464/56316852-60607b80-6129-11e9-927f-969b87d6e68c.png)
![image](https://user-images.githubusercontent.com/7015464/56316861-68b8b680-6129-11e9-8982-ea68f510684f.png)

Some things to note:
- if there are not enough chips to have a multiline list, the list will not be collapsible
- you can use the `size` prop on both individual Chip components and the whole ChipList component.  The latter will apply the size to all Chips within the container.  
- if `activeColor` is not set, the default is 'accent' and solid.  However, if an `activeColor` is set, the Chip has a "outline" style, as per other use-cases.  

Preview [here](https://deploy-preview-740--serene-shannon-8198f2.netlify.com/docs/packages/axiom-components/chip)