### PR TITLE
fix(Slider/Range): set of fixes

### DIFF
--- a/packages/axiom-components/src/Slider/Handle.js
+++ b/packages/axiom-components/src/Slider/Handle.js
@@ -21,6 +21,8 @@ export default class Handle extends Component {
     valueAsPercentage: PropTypes.number,
     /** Value formatter for the tooltip */
     valueFormatter: PropTypes.func,
+    /** Enables a value indicating tooltip */
+    withTooltip: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -28,13 +30,15 @@ export default class Handle extends Component {
     isVisible: true,
     onMouseDown: () => {},
     valueFormatter: (n) => n,
+    withTooltip: false,
   };
 
   render() {
 
-    const { disabled, onMouseDown, isVisible, value, valueAsPercentage, valueFormatter } = this.props;
+    const { disabled, onMouseDown, isVisible, value, valueAsPercentage, valueFormatter, withTooltip } = this.props;
     return (
       <Position
+          enabled={ withTooltip }
           isVisible={ isVisible }
           showArrow>
         <PositionTarget>

--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -54,8 +54,9 @@ export default class Range extends Component {
   }
 
   ensureValueInRange(value) {
-    const { min, max } = this.props;
-    return Math.max(min, Math.min(value, max));
+    const { min, max, step } = this.props;
+    const valueInRange = Math.max(min, Math.min(value, max));
+    return step * Math.round(valueInRange / step);
   }
 
   getPercentageFromValue(value) {
@@ -65,13 +66,12 @@ export default class Range extends Component {
   }
 
   getValueFromPosition(clientX) {
-    const { max, min, step } = this.props;
+    const { max, min } = this.props;
     const { left: posMin, right: posMax } = this.container.getBoundingClientRect();
 
     const value = (clientX - posMin) * (max - min) / (posMax - posMin) + min;
-    const roundedValue = step * Math.round(value / step);
 
-    return this.ensureValueInRange(roundedValue);
+    return this.ensureValueInRange(value);
   }
 
   getValues(clientX) {

--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -197,7 +197,7 @@ export default class Range extends Component {
     const sliderMarkerStyle = { left:`${markerValueAsPercentage}%` };
 
     return (
-      <Base { ...omit(rest, ['onSlideEnd']) }
+      <Base { ...omit(rest, ['onSlideEnd', 'min', 'max', 'step']) }
           className={ classes }
           onBlur={ this.handleBlur }
           onFocus={ disabled ? null : this.handleFocus }

--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -77,9 +77,12 @@ export default class Range extends Component {
   getValues(clientX) {
     const { values } = this.props;
 
-    values[this.focusedHandleIndex] = this.getValueFromPosition(clientX);
-
-    return values;
+    return values.map((value, index) => {
+      if (index === this.focusedHandleIndex) {
+        return this.getValueFromPosition(clientX);
+      }
+      return value;
+    });
   }
 
   getClosestHandleIndex(clientX) {

--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -59,19 +59,19 @@ export default class Range extends Component {
   }
 
   getPercentageFromValue(value) {
-    const { max } = this.props;
+    const { min, max } = this.props;
     const valueInRange = this.ensureValueInRange(value);
-    return (valueInRange / max) * 100;
+    return ((valueInRange - min) / (max - min)) * 100;
   }
 
   getValueFromPosition(clientX) {
     const { max, min, step } = this.props;
     const { left: posMin, right: posMax } = this.container.getBoundingClientRect();
 
-    const posAsPercentage = Math.max(0, Math.min((clientX - posMin) / (posMax - posMin), 100));
-    const value = step * Math.round(posAsPercentage * (max - min) / step);
+    const value = (clientX - posMin) * (max - min) / (posMax - posMin) + min;
+    const roundedValue = step * Math.round(value / step);
 
-    return this.ensureValueInRange(value);
+    return this.ensureValueInRange(roundedValue);
   }
 
   getValues(clientX) {

--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -93,6 +93,9 @@ export default class Range extends Component {
         closestDist = currentDist;
         return currentIndex;
       }
+      if (currentDist === closestDist && xValue > currentValue) {
+        return currentIndex;
+      }
       return closestIndex;
     }, 0);
   }

--- a/packages/axiom-components/src/Slider/Range.test.js
+++ b/packages/axiom-components/src/Slider/Range.test.js
@@ -33,35 +33,58 @@ describe('Range', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('prevents Handle crossing', () => {
-    Element.prototype.getBoundingClientRect = jest.fn(() => {
-      return {
-        width: 120,
-        height: 120,
-        top: 0,
-        left: 0,
-        bottom: 0,
-        right: 20,
-      };
+  describe('withBoundingClientRect', () => {
+    beforeEach(() => {
+      Element.prototype.getBoundingClientRect = jest.fn(() => {
+        return {
+          width: 120,
+          height: 120,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 20,
+        };
+      });
     });
 
-    const props = {
-      ...requiredProps,
-      onChange: jest.fn(),
-      values: [1, 2],
-    };
-    const component = mount(<Range { ...props } />);
+    it('picks the right handle when the handles are on the same value', () => {
+      const props = {
+        ...requiredProps,
+        onChange: jest.fn(),
+        values: [2, 2],
+      };
+      const component = mount(<Range { ...props } />);
 
-    const tracker = component.find('.ax-slider__track');
-    tracker.simulate('mousedown', { clientX: 0 });
+      const tracker = component.find('.ax-slider__track');
+      tracker.simulate('mousedown', { clientX: 5 });
 
-    expect(props.onChange).toHaveBeenCalledTimes(1);
-    expect(props.onChange).toHaveBeenCalledWith([0, 2]);
+      const event = new MouseEvent('mousemove', { clientX: 5 });
+      document.dispatchEvent(event);
 
-    const event = new MouseEvent('mousemove', { clientX: 3 });
-    document.dispatchEvent(event);
+      tracker.simulate('mouseup', { clientX: 5 });
 
-    expect(props.onChange).toHaveBeenCalledTimes(2);
-    expect(props.onChange).toHaveBeenCalledWith([2, 2]);
+      expect(props.onChange).toHaveBeenCalledWith([2, 5]);
+    });
+
+    it('prevents Handle crossing', () => {
+      const props = {
+        ...requiredProps,
+        onChange: jest.fn(),
+        values: [1, 2],
+      };
+      const component = mount(<Range { ...props } />);
+
+      const tracker = component.find('.ax-slider__track');
+      tracker.simulate('mousedown', { clientX: 0 });
+
+      expect(props.onChange).toHaveBeenCalledTimes(1);
+      expect(props.onChange).toHaveBeenCalledWith([0, 2]);
+
+      const event = new MouseEvent('mousemove', { clientX: 3 });
+      document.dispatchEvent(event);
+
+      expect(props.onChange).toHaveBeenCalledTimes(2);
+      expect(props.onChange).toHaveBeenCalledWith([2, 2]);
+    });
   });
 });

--- a/packages/axiom-components/src/Slider/Slider.js
+++ b/packages/axiom-components/src/Slider/Slider.js
@@ -129,7 +129,7 @@ export default class Slider extends Component {
     });
 
     return (
-      <Base { ...omit(rest, ['onSlideEnd']) }
+      <Base { ...omit(rest, ['onSlideEnd', 'min', 'max', 'step']) }
           className={ classes }
           onBlur={ this.handleBlur }
           onFocus={ disabled ? null : this.handleFocus }

--- a/packages/axiom-components/src/Slider/Slider.js
+++ b/packages/axiom-components/src/Slider/Slider.js
@@ -53,10 +53,10 @@ export default class Slider extends Component {
   getValue(clientX) {
     const { max, min, step } = this.props;
 
-    const posAsPercentage = Math.max(0, Math.min((clientX - this.posMin) / (this.posMax - this.posMin), 100));
-    const value = step * Math.round(posAsPercentage * (max - min) / step);
+    const value = (clientX - this.posMin) * (max - min) / (this.posMax - this.posMin) + min;
+    const roundedValue = step * Math.round(value / step);
 
-    return Math.max(min, Math.min(value, max));
+    return Math.max(min, Math.min(roundedValue, max));
   }
 
   componentWillUnmount() {
@@ -123,7 +123,7 @@ export default class Slider extends Component {
     const { disabled, max, min, size, value, valueFormatter, withTooltip, ...rest } = this.props;
     const { isDragging, isMouseOver } = this.state;
     const valueInRange = Math.max(min, Math.min(value, max));
-    const valueAsPercentage = (valueInRange / max) * 100;
+    const valueAsPercentage = ((valueInRange - min) / (max - min)) * 100;
     const classes = classnames('ax-slider', `ax-slider--${size}`, {
       'ax-slider--disabled': disabled,
     });

--- a/packages/axiom-components/src/Slider/__snapshots__/Handle.test.js.snap
+++ b/packages/axiom-components/src/Slider/__snapshots__/Handle.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Handle renders with custom props 1`] = `
 <Position
   boundariesElement="viewport"
-  enabled={true}
+  enabled={false}
   flip="clockwise"
   isVisible={false}
   offset="middle"
@@ -40,7 +40,7 @@ exports[`Handle renders with custom props 1`] = `
 exports[`Handle renders with defaultProps 1`] = `
 <Position
   boundariesElement="viewport"
-  enabled={true}
+  enabled={false}
   flip="clockwise"
   isVisible={true}
   offset="middle"

--- a/packages/axiom-components/src/Slider/__snapshots__/Range.test.js.snap
+++ b/packages/axiom-components/src/Slider/__snapshots__/Range.test.js.snap
@@ -3,14 +3,11 @@
 exports[`Range renders with custom props 1`] = `
 <div
   className="ax-slider ax-slider--medium"
-  max={20}
-  min={0}
   onBlur={[Function]}
   onChange={[MockFunction]}
   onFocus={[Function]}
   onMouseLeave={[Function]}
   onMouseOver={[Function]}
-  step={0.1}
   tabIndex="0"
 >
   <div
@@ -21,8 +18,8 @@ exports[`Range renders with custom props 1`] = `
       className="ax-slider__fill"
       style={
         Object {
-          "left": "15.15%",
-          "width": "47.85%",
+          "left": "15%",
+          "width": "48.000000000000014%",
         }
       }
     />
@@ -41,14 +38,11 @@ exports[`Range renders with custom props 1`] = `
 exports[`Range renders with defaultProps 1`] = `
 <div
   className="ax-slider ax-slider--small"
-  max={20}
-  min={0}
   onBlur={[Function]}
   onChange={[MockFunction]}
   onFocus={[Function]}
   onMouseLeave={[Function]}
   onMouseOver={[Function]}
-  step={1}
   tabIndex="0"
 >
   <div
@@ -59,8 +53,8 @@ exports[`Range renders with defaultProps 1`] = `
       className="ax-slider__fill"
       style={
         Object {
-          "left": "15.15%",
-          "width": "47.85%",
+          "left": "15%",
+          "width": "50%",
         }
       }
     />

--- a/packages/axiom-components/src/Slider/__snapshots__/Slider.test.js.snap
+++ b/packages/axiom-components/src/Slider/__snapshots__/Slider.test.js.snap
@@ -8,7 +8,6 @@ exports[`Slider renders with custom props 1`] = `
   onFocus={[Function]}
   onMouseLeave={[Function]}
   onMouseOver={[Function]}
-  step={0.1}
   tabIndex="0"
 >
   <div
@@ -44,7 +43,6 @@ exports[`Slider renders with defaultProps 1`] = `
   onFocus={[Function]}
   onMouseLeave={[Function]}
   onMouseOver={[Function]}
-  step={1}
   tabIndex="0"
 >
   <div


### PR DESCRIPTION
This PR fixes four bugs from the initial implementation.

The first bug is where when the two handles were on the same values it was impossible to pick and move the upper handle any more.

The second bug is where the `values` prop was being mutated resulting in the state of the wrapping component being modified without calling `setState`.

The third bug is about the `withTooltip` option not being passed to the Handle component.

The fourth bug is about calculating the right position when `min` option is different from 0.