### PR TITLE
chore: add defaults context props

### DIFF
--- a/packages/axiom-components/src/Dropdown/DropdownReactContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownReactContext.js
@@ -1,3 +1,8 @@
 import React from 'react';
 
-export default React.createContext();
+export default React.createContext({
+  closeDropdown: () => {},
+  openDropdown: () => {},
+  toggleDropdown: () => {},
+  dropdownRef: () => {},
+});


### PR DESCRIPTION
This PR adds default values for the `DropdownReactContext`.

It follows https://github.com/BrandwatchLtd/axiom-react/pull/735 where the React context was being upgraded to use the newer context API.

In cases where the context was not initialised by a `Provider` (e.g. tests for Custom Dropdown components in Analytics), the `handleClick` function of `DropdownMenuItem` was failing because the context was undefined and it couldn't be destructured. https://github.com/BrandwatchLtd/axiom-react/pull/735/files#diff-aa76d52af9329b3bdab3323aa96f9233R38 