### PR TITLE
Textinput icon tooltip

### DIFF
--- a/packages/axiom-components/src/Form/TextInputIcon.js
+++ b/packages/axiom-components/src/Form/TextInputIcon.js
@@ -6,7 +6,7 @@ import Icon from '../Icon/Icon';
 import Link from '../Typography/Link';
 import Tooltip from '../Tooltip/Tooltip';
 import TooltipContent from '../Tooltip/TooltipContent';
-import TooltipContext from '../Tooltip/TooltipContext';
+import TooltipContext, { TooltipContextRef } from '../Tooltip/TooltipContext';
 import TooltipSource from '../Tooltip/TooltipSource';
 import TooltipTarget from '../Tooltip/TooltipTarget';
 
@@ -39,13 +39,13 @@ export default class TextInputIcon extends Component {
           <Icon name={ name } size="1rem" textColor={ iconColor } />
         </TooltipTarget>
         <TooltipSource width="auto">
-          <TooltipContext>
-            { isComponent(tooltip, TooltipContent) ? tooltip : (
+          { isComponent(tooltip, TooltipContextRef) ? tooltip : (
+            <TooltipContext>
               <TooltipContent size="tiny">
                 { tooltip }
               </TooltipContent>
-            ) }
-          </TooltipContext>
+            </TooltipContext>
+          ) }
         </TooltipSource>
       </Tooltip>
     ) : (<Icon name={ name } size="1rem" textColor={ iconColor } />);

--- a/packages/axiom-components/src/Form/TextInputIcon.test.js
+++ b/packages/axiom-components/src/Form/TextInputIcon.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { shallow } from 'enzyme';
 import TextInputIcon from './TextInputIcon';
+import TooltipContext from '../Tooltip/TooltipContext';
 import TooltipContent from '../Tooltip/TooltipContent';
 
 const getComponent = (props) =>
@@ -58,8 +59,10 @@ describe('TextInputIcon', () => {
     expect(wrapper.find(TooltipContent)).toHaveLength(1);
   });
 
-  it('renders with tooltip when TooltipContent passed', () => {
-    props.tooltip = (<TooltipContent size="tiny">I am a tooltip</TooltipContent>);
+  it('renders with tooltip when TooltipContext passed', () => {
+    props.tooltip = (
+      <TooltipContext><TooltipContent size="tiny">I am a tooltip</TooltipContent></TooltipContext>
+    );
 
     const component = getComponent(props);
     const tree = component.toJSON();
@@ -68,6 +71,6 @@ describe('TextInputIcon', () => {
     wrapper.simulate('mouseenter');
 
     expect(tree).toMatchSnapshot();
-    expect(wrapper.find(TooltipContent)).toHaveLength(1);
+    expect(wrapper.find(TooltipContext)).toHaveLength(1);
   });
 });

--- a/packages/axiom-components/src/Form/__snapshots__/TextInputIcon.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/TextInputIcon.test.js.snap
@@ -93,7 +93,7 @@ exports[`TextInputIcon renders with the correct iconColor 1`] = `
 </span>
 `;
 
-exports[`TextInputIcon renders with tooltip when TooltipContent passed 1`] = `
+exports[`TextInputIcon renders with tooltip when TooltipContext passed 1`] = `
 <span
   className="ax-input__icon ax-input__icon--align-right"
 >

--- a/packages/axiom-components/src/Tooltip/TooltipContext.js
+++ b/packages/axiom-components/src/Tooltip/TooltipContext.js
@@ -2,10 +2,15 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Context from '../Context/Context';
 
+export const TooltipContextRef = 'TooltipContext';
+
 export default class TooltipContext extends Component {
   static propTypes = {
     color: PropTypes.oneOf(['success', 'warning', 'error', 'info', 'carbon', 'white']),
   }
+
+  static typeRef = TooltipContextRef;
+
   render() {
 
     const {

--- a/site/components/Documentation/Resources/Components/Form.js
+++ b/site/components/Documentation/Resources/Components/Form.js
@@ -11,12 +11,18 @@ import {
   TextInputButton,
   TextInputIcon,
   InlineValidation,
+  TooltipContent,
+  TooltipContext,
 } from '@brandwatch/axiom-components';
 import {
   DocumentationApi,
   DocumentationContent,
   DocumentationShowCase,
 } from '@brandwatch/axiom-documentation-viewer';
+
+const getTextInputIconTooltip = () => (
+  <TooltipContext color="carbon"><TooltipContent>Some tooltip</TooltipContent></TooltipContext>
+);
 
 export default class Documentation extends Component {
   render() {
@@ -42,7 +48,7 @@ export default class Documentation extends Component {
                   onChange={ (setValue, getValue, event) => setValue('TextInput', 'value', event.target.value) }
                   placeholder="Write in me"
                   size="medium">
-                <TextInputIcon align="left" name="magnify-glass" />
+                <TextInputIcon align="left" name="magnify-glass" tooltip={ getTextInputIconTooltip() } />
                 <TextInputButton>Button</TextInputButton>
               </TextInput>
             </DocumentationShowCase>


### PR DESCRIPTION
Sorry @lpoulter and @Binarytales, I should have checked with @Flawwles earlier on this. He wants us to be able to specify the colour for the tooltip, hence I've changed it to allow us to pass in the TooltipContext instead.

I'm not necessarily super keen on the `static typeRef` pattern to validate the type of the tooltip prop but have gone with it firstly for consistency, and secondly coz I couldn't get the other way to work for `TooltipContext`.

Have also added a tooltip to the example in the docs, happy to remove that if you want; the code's slightly gnarly as we're passing a React element as a prop; but I think it's worth showing how it's done.