### PR TITLE
fix(Range) ensure values are in bounds

### DIFF
--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -45,12 +45,24 @@ export default class Range extends Component {
       isMouseOver: false,
     };
 
+    this.ensureBoundsInRange();
+
     this.handleBlur = this.handleBlur.bind(this);
     this.handleFocus = this.handleFocus.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleMouseDown = this.handleMouseDown.bind(this);
     this.handleMouseMove = this.handleMouseMove.bind(this);
     this.handleMouseUp = this.handleMouseUp.bind(this);
+  }
+
+  ensureBoundsInRange() {
+    const { values } = this.props;
+
+    const valuesInRange = values.map(value => this.ensureValueInRange(value));
+
+    if (values.some(value => !valuesInRange.includes(value))) {
+      this.onChange(valuesInRange);
+    }
   }
 
   ensureValueInRange(value) {

--- a/packages/axiom-components/src/Slider/Range.test.js
+++ b/packages/axiom-components/src/Slider/Range.test.js
@@ -33,6 +33,16 @@ describe('Range', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('resets its values when they are out of bounds', () => {
+    getComponent({
+      min: 0,
+      max: 1,
+      values: [-1, 2],
+    });
+
+    expect(requiredProps.onChange).toHaveBeenCalledWith([0, 1]);
+  });
+
   describe('withBoundingClientRect', () => {
     beforeEach(() => {
       Element.prototype.getBoundingClientRect = jest.fn(() => {

--- a/packages/axiom-components/src/Slider/__snapshots__/Range.test.js.snap
+++ b/packages/axiom-components/src/Slider/__snapshots__/Range.test.js.snap
@@ -4,7 +4,34 @@ exports[`Range renders with custom props 1`] = `
 <div
   className="ax-slider ax-slider--medium"
   onBlur={[Function]}
-  onChange={[MockFunction]}
+  onChange={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Array [
+            3,
+            13,
+          ],
+        ],
+        Array [
+          Array [
+            3,
+            12.600000000000001,
+          ],
+        ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
   onFocus={[Function]}
   onMouseLeave={[Function]}
   onMouseOver={[Function]}
@@ -39,7 +66,24 @@ exports[`Range renders with defaultProps 1`] = `
 <div
   className="ax-slider ax-slider--small"
   onBlur={[Function]}
-  onChange={[MockFunction]}
+  onChange={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          Array [
+            3,
+            13,
+          ],
+        ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
   onFocus={[Function]}
   onMouseLeave={[Function]}
   onMouseOver={[Function]}


### PR DESCRIPTION
This PR fixes a bug where when the values were out of bound, the handles were being forcefully positioned at the boundaries but their internal values were kept out of bound, resulting on a miscalculation of the nearest handle.

Now the outbound values are reset to the boundaries on component creation so that the later calculation of the nearest handle is correct.