### PR TITLE
fix(DatePicker): pass on initialDate prop

### DIFF
--- a/packages/axiom-components/src/DatePicker/DatePicker.js
+++ b/packages/axiom-components/src/DatePicker/DatePicker.js
@@ -7,15 +7,16 @@ import DatePickerContext from './DatePickerContext';
 
 export default class DatePicker extends Component {
   static propTypes = {
+    /**
+     * The date that should be shown to the user when the picker opens.
+     * When a selected date or range is given, this supersedes this
+     * property. Defaults to 'today'.
+     */
+    calendarOpenDate: PropTypes.instanceOf(Date),
     /** The element to position the DatePicker around */
     children: PropTypes.node.isRequired,
     /** A lower limit to the earliest date that can be selected */
     earliestSelectableDate: PropTypes.instanceOf(Date),
-    /**
-     * The date that should be initially shown to the user. When a selected date
-     * or range is given, this supersedes this property. Defaults to 'today'.
-     */
-    initialDate: PropTypes.instanceOf(Date),
     /** An upper limit to the latest date that can be selected */
     latestSelectableDate: PropTypes.instanceOf(Date),
     /** Callback for when the apply button has been clicked */

--- a/packages/axiom-components/src/DatePicker/DatePickerContext.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerContext.js
@@ -10,8 +10,8 @@ import './DatePicker.css';
 
 export default class DatePickerContext extends Component {
   static propTypes = {
+    calendarOpenDate: PropTypes.instanceOf(Date),
     earliestSelectableDate: PropTypes.instanceOf(Date),
-    initialDate: PropTypes.instanceOf(Date),
     latestSelectableDate: PropTypes.instanceOf(Date),
     onApply: PropTypes.func,
     onCancel: PropTypes.func,
@@ -38,6 +38,7 @@ export default class DatePickerContext extends Component {
 
   render() {
     const {
+      calendarOpenDate,
       earliestSelectableDate,
       latestSelectableDate,
       rangeSelect,
@@ -59,6 +60,7 @@ export default class DatePickerContext extends Component {
       <DropdownContext { ...rest }>
         <DropdownContent hasFullSeparator>
           <DatePickerSelection
+              calendarOpenDate={ calendarOpenDate }
               earliestSelectableDate={ earliestSelectableDate }
               latestSelectableDate={ latestSelectableDate }
               onSelect={ onSelect }

--- a/packages/axiom-components/src/DatePicker/DatePickerSelection.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerSelection.js
@@ -17,8 +17,8 @@ import './DatePicker.css';
 
 export default class DatePickerSelection extends Component {
   static propTypes = {
+    calendarOpenDate: PropTypes.instanceOf(Date),
     earliestSelectableDate: PropTypes.instanceOf(Date),
-    initialDate: PropTypes.instanceOf(Date),
     latestSelectableDate: PropTypes.instanceOf(Date),
     onSelect: PropTypes.func.isRequired,
     view: PropTypes.string,
@@ -29,7 +29,7 @@ export default class DatePickerSelection extends Component {
     super(props);
     this.handleDaySelect = this.handleDaySelect.bind(this);
 
-    const { initialDate, rangeSelect, selectedDate } = this.props;
+    const { calendarOpenDate, rangeSelect, selectedDate } = this.props;
     const [ selectedStartDate, selectedEndDate ] = orderDates(
       this.props.selectedStartDate,
       this.props.selectedEndDate,
@@ -37,7 +37,7 @@ export default class DatePickerSelection extends Component {
 
     const activeStartDate = dateOrNow(
       (rangeSelect ? selectedStartDate : selectedDate) ||
-      initialDate
+      calendarOpenDate
     );
 
     const activeEndDate = rangeSelect && selectedEndDate


### PR DESCRIPTION
In https://github.com/BrandwatchLtd/axiom-react/pull/614 `initialDate` was missed to be passed down to the new `DatePickerSelection`.

With `initialDate` you can define which month should be shown, when a user opens the dialog, without setting any date/date range as selected. So IMO it's still useful and should be kept.

This PR fixes `initialDate` to work again.