### PR TITLE
feat(Dialog): Add classname prop to Dialog components

### DIFF
--- a/packages/axiom-components/src/Dialog/Dialog.js
+++ b/packages/axiom-components/src/Dialog/Dialog.js
@@ -9,6 +9,8 @@ export default class Dialog extends Component {
   static propTypes = {
     /** Content inside the Dialog */
     children: PropTypes.node,
+    /** Class name to be appended to the element */
+    className: PropTypes.string,
     /** Stops the dialog closing when the mask is clicked */
     closeOnOverlayClick: PropTypes.bool,
     /** Control for the Dialog stretching to the windows size */
@@ -55,6 +57,7 @@ export default class Dialog extends Component {
   render() {
     const {
       children,
+      className,
       closeOnOverlayClick,
       fullscreen,
       onRequestClose,
@@ -68,7 +71,7 @@ export default class Dialog extends Component {
 
     const classes = classnames('ax-dialog', {
       'ax-dialog--fullscreen': fullscreen,
-    });
+    }, className);
 
     return (
       <Modal { ...rest }

--- a/packages/axiom-components/src/Dialog/DialogBody.js
+++ b/packages/axiom-components/src/Dialog/DialogBody.js
@@ -1,18 +1,24 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Base from '../Base/Base';
+import classnames from 'classnames';
 
 export default class DialogBody extends Component {
   static propTypes = {
     /** The main content side a Dialog that occupies most of the space */
     children: PropTypes.node,
+    /** Class name to be appended to the element */
+    className: PropTypes.string,
   };
 
+
   render() {
-    const { children, ...rest } = this.props;
+    const { children, className, ...rest } = this.props;
+
+    const classes = classnames('ax-dialog__body', className);
 
     return (
-      <Base { ...rest } className="ax-dialog__body">
+      <Base { ...rest } className={ classes }>
         { children }
       </Base>
     );

--- a/packages/axiom-components/src/Dialog/DialogFooter.js
+++ b/packages/axiom-components/src/Dialog/DialogFooter.js
@@ -1,18 +1,23 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import Base from '../Base/Base';
 
 export default class DialogFooter extends Component {
   static propTypes = {
     /** Footer content inside the Dialog, a good place for some buttons */
     children: PropTypes.node,
+    /** Class name to be appended to the element */
+    className: PropTypes.string,
   };
 
   render() {
-    const { children, ...rest } = this.props;
+    const { children, className, ...rest } = this.props;
+
+    const classes = classnames('ax-dialog__footer', className);
 
     return (
-      <Base { ...rest } className="ax-dialog__footer">
+      <Base { ...rest } className={ classes }>
         { children }
       </Base>
     );

--- a/packages/axiom-components/src/Dialog/DialogHeader.js
+++ b/packages/axiom-components/src/Dialog/DialogHeader.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import Base from '../Base/Base';
 import Grid from '../Grid/Grid';
 import GridCell from '../Grid/GridCell';
@@ -10,6 +11,8 @@ export default class DialogHeader extends Component {
   static propTypes = {
     /** Header content inside the Dialog, a good place for a title */
     children: PropTypes.node,
+    /** Class name to be appended to the element */
+    className: PropTypes.string,
   };
 
   static contextTypes = {
@@ -18,10 +21,12 @@ export default class DialogHeader extends Component {
 
   render() {
     const { onRequestClose } = this.context;
-    const { children, ...rest } = this.props;
+    const { children, className, ...rest } = this.props;
+
+    const classes = classnames('ax-dialog__header', className);
 
     return (
-      <Base { ...rest } className="ax-dialog__header">
+      <Base { ...rest } className={ classes }>
         <Grid responsive={ false } verticalAlign="middle">
           <GridCell>
             { children }


### PR DESCRIPTION
Allows a custom class to be passed to each of the 4 `Dialog` component.
This saves these sort of `shenanigans`

```
<div className="apply-some-sweet-sweet-layout">
  <DialogBody>...</DialogBody>
</div>
```