### PR TITLE
fix(InputWrapper): Apply margin to hint when label is inline

### DIFF
--- a/packages/axiom-components/src/Form/InputWrapper.css
+++ b/packages/axiom-components/src/Form/InputWrapper.css
@@ -49,6 +49,14 @@
   flex-shrink: 0;
 }
 
+.ax-input__wrapper--inline .ax-input__hint-wrapper {
+  align-items: center;
+}
+
+.ax-input__wrapper--inline .ax-input__hint {
+  margin-left: var(--spacing-grid-size--x1);
+}
+
 .ax-input__wrapper--target .ax-input {
   cursor: pointer;
 }

--- a/packages/axiom-components/src/Form/InputWrapper.js
+++ b/packages/axiom-components/src/Form/InputWrapper.js
@@ -73,7 +73,7 @@ export default class InputWrapper extends Component {
               {
                 usageHint && (
                   <div className="ax-input__hint">
-                    <UsageHintComponent position={ usageHintPosition } >
+                    <UsageHintComponent position={ usageHintPosition }>
                       { usageHint }
                     </UsageHintComponent>
                   </div>

--- a/site/components/Documentation/Resources/Components/Form.js
+++ b/site/components/Documentation/Resources/Components/Form.js
@@ -42,6 +42,20 @@ export default class Documentation extends Component {
                   onChange={ (setValue, getValue, event) => setValue('TextInput', 'value', event.target.value) }
                   placeholder="Write in me"
                   size="medium"/>
+              <TextInput
+                  inlineLabel
+                  label="An inline label"
+                  onChange={ (setValue, getValue, event) => setValue('TextInput', 'value', event.target.value) }
+                  placeholder="Write in me"
+                  size="medium"><TextInputIcon align="left" name="magnify-glass" tooltip={ getTextInputIconTooltip() } /></TextInput>
+              <TextInput
+                  inlineLabel
+                  label="Lorem Ipsum"
+                  onChange={ (setValue, getValue, event) => setValue('TextInput', 'value', event.target.value) }
+                  onClear={ (setValue) => setValue('TextInput', 'value', '') }
+                  placeholder="Write in me"
+                  size="medium"
+                  usageHint="This is a usage hint" />
             </DocumentationShowCase>
           </GridCell>
 


### PR DESCRIPTION
Fix the label hint margin when inline. 

Preview [here](https://deploy-preview-758--serene-shannon-8198f2.netlify.com/docs/packages/axiom-components/form)

<img width="286" alt="Screen Shot 2019-06-07 at 12 43 17" src="https://user-images.githubusercontent.com/3940567/59101797-0a86a380-8922-11e9-9ee8-81c3b65a0f25.png">
