### PR TITLE
fix: Allow functions as ref props

### DIFF
--- a/packages/axiom-components/src/Base/Base.js
+++ b/packages/axiom-components/src/Base/Base.js
@@ -20,7 +20,7 @@ export default class Base extends Component {
       PropTypes.func,
     ]),
     /** Pass this prop to get ref to the Base Component instance. */
-    baseRef: PropTypes.object,
+    baseRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     /** Class name to be appended to the element */
     className: PropTypes.string,
     /** Adds ability to make an element invisible */

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -21,7 +21,7 @@ export default class TextInput extends Component {
     /** Display label inline */
     inlineLabel: PropTypes.bool,
     /** Pass this prop to get ref to the Text Component instance. */
-    inputRef: PropTypes.object,
+    inputRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     /** Applies styling to indicate the users input was invalid */
     invalid: PropTypes.bool,
     /** Adds a progress indicator the the right of the text input */


### PR DESCRIPTION
Currently it is only allowed to pass in objects, but in certain cases a function is needed as a ref prop (see https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node for more details/examples)