### PR TITLE
fix(Range): range sliders crossing over on mouse up

### DIFF
--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -71,6 +71,24 @@ export default class Range extends Component {
     return step * Math.round(valueInRange / step);
   }
 
+  ensureValuesDontCrossover(values) {
+    const orderedValues = [...values];
+
+    if (orderedValues[0] > orderedValues[1]) {
+      switch (this.focusedHandleIndex) {
+      case 0:
+        orderedValues[0] = orderedValues[1];
+        break;
+      case 1:
+        orderedValues[1] = orderedValues[0];
+        break;
+      default:
+        throw new Error(`Unknown handle ${this.focusedHandleIndex} was in focus: change is not applied`);
+      }
+    }
+    return orderedValues;
+  }
+
   getPercentageFromValue(value) {
     const { min, max } = this.props;
     const valueInRange = this.ensureValueInRange(value);
@@ -137,9 +155,11 @@ export default class Range extends Component {
   handleMouseUp(event) {
     const { onSlideEnd } = this.props;
     const { clientX } = event;
+    const values = this.getValues(clientX);
+    const orderedValues = this.ensureValuesDontCrossover(values);
 
     this.setState({ draggedHandleIndex: null });
-    onSlideEnd && onSlideEnd(this.getValues(clientX));
+    onSlideEnd && onSlideEnd(orderedValues);
 
     document.removeEventListener('mousemove', this.handleMouseMove);
     document.removeEventListener('mouseup', this.handleMouseUp);
@@ -178,22 +198,7 @@ export default class Range extends Component {
   }
 
   onChange(values) {
-    const { onChange } = this.props;
-
-    if (values[0] > values[1]) {
-      switch (this.focusedHandleIndex) {
-      case 0:
-        values[0] = values[1];
-        break;
-      case 1:
-        values[1] = values[0];
-        break;
-      default:
-        throw new Error(`Unknown handle ${this.focusedHandleIndex} was in focus: change is not applied`);
-      }
-    }
-
-    onChange(values);
+    this.props.onChange(this.ensureValuesDontCrossover(values));
   }
 
   render() {

--- a/packages/axiom-components/src/Slider/Range.test.js
+++ b/packages/axiom-components/src/Slider/Range.test.js
@@ -76,7 +76,7 @@ describe('Range', () => {
       expect(props.onChange).toHaveBeenCalledWith([2, 5]);
     });
 
-    it('prevents Handle crossing', () => {
+    it('prevents Handle crossing on change', () => {
       const props = {
         ...requiredProps,
         onChange: jest.fn(),
@@ -95,6 +95,27 @@ describe('Range', () => {
 
       expect(props.onChange).toHaveBeenCalledTimes(2);
       expect(props.onChange).toHaveBeenCalledWith([2, 2]);
+    });
+
+    it('prevents Handle crossing on slide end', () => {
+      const props = {
+        ...requiredProps,
+        onSlideEnd: jest.fn(),
+        values: [1, 2],
+      };
+      const component = mount(<Range { ...props } />);
+
+      const tracker = component.find('.ax-slider__track');
+      tracker.simulate('mouseup', { clientX: 0 });
+
+      expect(props.onSlideEnd).toHaveBeenCalledTimes(1);
+      expect(props.onSlideEnd).toHaveBeenCalledWith([0, 2]);
+
+      const event = new MouseEvent('mouseup', { clientX: 3 });
+      document.dispatchEvent(event);
+
+      expect(props.onSlideEnd).toHaveBeenCalledTimes(2);
+      expect(props.onSlideEnd).toHaveBeenCalledWith([2, 2]);
     });
   });
 });

--- a/packages/axiom-components/src/Slider/Range.test.js
+++ b/packages/axiom-components/src/Slider/Range.test.js
@@ -103,18 +103,16 @@ describe('Range', () => {
         onSlideEnd: jest.fn(),
         values: [1, 2],
       };
+
       const component = mount(<Range { ...props } />);
 
       const tracker = component.find('.ax-slider__track');
-      tracker.simulate('mouseup', { clientX: 0 });
+      tracker.simulate('mousedown', { clientX: 0 });
+
+      const event2 = new MouseEvent('mouseup', { clientX: 3 });
+      document.dispatchEvent(event2);
 
       expect(props.onSlideEnd).toHaveBeenCalledTimes(1);
-      expect(props.onSlideEnd).toHaveBeenCalledWith([0, 2]);
-
-      const event = new MouseEvent('mouseup', { clientX: 3 });
-      document.dispatchEvent(event);
-
-      expect(props.onSlideEnd).toHaveBeenCalledTimes(2);
       expect(props.onSlideEnd).toHaveBeenCalledWith([2, 2]);
     });
   });


### PR DESCRIPTION
The code ensuring that the handles were not crossing over was only called on mousemove but it also needs to be called on mouseup.