### PR TITLE
fix(DropdownContext): ensure ref value is not null

### DIFF
--- a/packages/axiom-components/src/Dropdown/DropdownContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContext.js
@@ -67,7 +67,7 @@ export default class DropdownContext extends Component {
     }
 
     const dropdownRef = this.context.dropdownRef();
-    if (!dropdownRef.contains(event.target) && !this.el.contains(event.target)) {
+    if (dropdownRef && !dropdownRef.contains(event.target) && !this.el.contains(event.target)) {
       return this.context.closeDropdown();
     }
   }


### PR DESCRIPTION
In our New Relic project, we see many errors regarding to `Cannot read property 'contains' of undefined`. I was able to track it down to this component where a null check was missing in case `dropdownRef()` returns `null`. 