### PR TITLE
chore(publishing): hard code registry

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -17,4 +17,4 @@ yarn
 yarn build:packages
 
 # Publish
-npx lerna publish --npm-client npm --conventional-commits --yes --git-remote upstream
+npx lerna publish --npm-client npm --registry https://registry.npmjs.org/ --conventional-commits --yes --git-remote upstream


### PR DESCRIPTION
Hardcode the registry we currently publish to, so e.g. a local `~/.npmrc` does defined where the packages are published.