### PR TITLE
fix(DatePickerContext): the date range label shows the correct start date

### DIFF
--- a/packages/axiom-components/src/DatePicker/DatePickerContext.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerContext.js
@@ -82,7 +82,7 @@ export default class DatePickerContext extends Component {
               rangeSelect={ rangeSelect }
               selectedDate={ selectedDate }
               selectedEndDate={ selectedEndDate }
-              selectedStartDate={ selectedEndDate }
+              selectedStartDate={ selectedStartDate }
               view={ view } />
         </DropdownContent>
       </DropdownContext>


### PR DESCRIPTION
Brought up by @bwSpiceBall in the Axiom Clinic. 