### PR TITLE
Flag color fix

### DIFF
--- a/scripts/process_flags/lib/palette.js
+++ b/scripts/process_flags/lib/palette.js
@@ -5,10 +5,13 @@ module.exports = {
     palette.uiCarbonDarker,
     palette.uiWhiteNoise,
   ],
-  brand: Object.values(palette.productColors)
-    // Add additional colours to fill the gaps (e.g. red, navy)
-    .concat(...[
-      palette.sentimentNegativeActive,
-      palette.socialFacebookActive,
-    ]),
+  brand: [].concat(
+    Object.values(palette.productColors),
+    Object.values(palette.productActiveColors),
+    Object.values(palette.productHoverColors),
+    // Red
+    palette.sentimentNegativeActive,
+    // Navy
+    palette.socialTumblrHover
+  ),
 };


### PR DESCRIPTION
It looks like Facebook's brand change messed up our flags. The two should not be related but Axiom doesn't have a navy blue in the palette, so I've had to switch to Tumblr for now. Let's hope they don't rebrand…

Ideally I would like to make the colour matching smarter and prioritise hue over the full colour value, but this is a quick and easy fix.