### PR TITLE
fix(animicon): Changed Cross animation

### DIFF
--- a/packages/axiom-components/src/Icon/Animicon.css
+++ b/packages/axiom-components/src/Icon/Animicon.css
@@ -21,9 +21,9 @@
 .ax-animicon--cross {
   & .ax-animicon__path-1,
   & .ax-animicon__path-2 {
-    stroke-dasharray: 14;
-    stroke-dashoffset: 14;
-    animation-duration: var(--transition-time-base);
+    stroke-dasharray: 25;
+    stroke-dashoffset: 25;
+    animation-duration: var(--transition-time-slow);
     animation-fill-mode: forwards;
     animation-timing-function: var(--transition-function);
   }

--- a/packages/axiom-components/src/Icon/Animicon.css
+++ b/packages/axiom-components/src/Icon/Animicon.css
@@ -19,22 +19,13 @@
 }
 
 .ax-animicon--cross {
-  & .ax-animicon__path-1,
-  & .ax-animicon__path-2 {
-    stroke-dasharray: 25;
-    stroke-dashoffset: 25;
-    animation-duration: var(--transition-time-slow);
-    animation-fill-mode: forwards;
-    animation-timing-function: var(--transition-function);
-  }
-
-  & .ax-animicon__path-1 { animation-delay: 0ms; }
-  & .ax-animicon__path-2 { animation-delay: var(--transition-time-fast); }
+  stroke-dasharray: 25;
+  stroke-dashoffset: 25;
+  animation-duration: var(--transition-time-slow);
+  animation-fill-mode: forwards;
+  animation-timing-function: var(--transition-function);
 }
 
 .ax-animicon--cross-in {
-  & .ax-animicon__path-1,
-  & .ax-animicon__path-2 {
-    animation-name: ax-animicon-cross;
-  }
+  animation-name: ax-animicon-cross;
 }

--- a/packages/axiom-materials/src/icon_svgs/cross.svg
+++ b/packages/axiom-materials/src/icon_svgs/cross.svg
@@ -5,9 +5,8 @@
     <desc>Created with sketchtool.</desc>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="cross" fill-rule="nonzero" stroke="#000000" stroke-width="2.1">
-            <path d="M3.75,12.25 L12.25,3.75" id="Path" class="ax-animicon__path-1"></path>
-            <path d="M3.75,3.75 L12.25,12.25" id="Path" class="ax-animicon__path-2"></path>
+        <g id="cross" transform="translate(3.000000, 3.000000)" fill-rule="nonzero" stroke="#000000" stroke-width="2.1">
+          <path d="M5,5 L0.75,9.25 L5,5 L0.75,0.75 L5,5 Z M5,5 L9.25,0.75 L5,5 L9.25,9.25 L5,5 Z" id="Path" class="ax-animicon__path-1"></path>
         </g>
     </g>
 </svg>

--- a/packages/axiom-materials/src/icon_svgs/cross.svg
+++ b/packages/axiom-materials/src/icon_svgs/cross.svg
@@ -6,7 +6,7 @@
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="cross" transform="translate(3.000000, 3.000000)" fill-rule="nonzero" stroke="#000000" stroke-width="2.1">
-          <path d="M5,5 L0.75,9.25 L5,5 L0.75,0.75 L5,5 Z M5,5 L9.25,0.75 L5,5 L9.25,9.25 L5,5 Z" id="Path" class="ax-animicon__path-1"></path>
+          <path d="M5,5 L0.75,9.25 L5,5 L0.75,0.75 L5,5 Z M5,5 L9.25,0.75 L5,5 L9.25,9.25 L5,5 Z" id="Path"></path>
         </g>
     </g>
 </svg>


### PR DESCRIPTION
The cross icon has been created with two paths, this is to enable the animicon component to animate each path separately.

Because we created the cross with two overlapping paths, it means any time we used the cross icon with opacity, you saw the overlap..

Look at overlapping parts of the cross 🕵️‍♂️
![cross-before-after](https://user-images.githubusercontent.com/7532495/62880885-555bd780-bd26-11e9-8ab5-f796794b29f6.png)

This PR changes the animation of the cross, but I dont think its used much if at all?

This might not be the best solution, but hopefully we can get the ball rolling with this. 