### PR TITLE
NOTICKET Add color prop to EllipsisTooltip

### DIFF
--- a/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.js
+++ b/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.js
@@ -16,12 +16,14 @@ function elementHasEllipsis(ref = {}) {
 export default class EllipsisTooltip extends Component {
   static propTypes = {
     children: PropTypes.node,
+    color: PropTypes.oneOf(['carbon', 'white']),
     delay: PropTypes.bool,
     theme: PropTypes.oneOf(['day', 'night']),
     width: PropTypes.string,
   };
 
   static defaultProps = {
+    color: 'carbon',
     delay: true,
     theme: 'night',
     width: 'auto',
@@ -51,7 +53,7 @@ export default class EllipsisTooltip extends Component {
   }
 
   render() {
-    const { children, delay, width, theme, ...rest } = this.props;
+    const { children, color, delay, width, theme, ...rest } = this.props;
     const { hasEllipsis } = this.state;
 
     if (!hasEllipsis) {
@@ -70,7 +72,7 @@ export default class EllipsisTooltip extends Component {
           </Base>
         </TooltipTarget>
         <TooltipSource theme={ theme } width={ width }>
-          <TooltipContext>
+          <TooltipContext color={ color }>
             <TooltipContent>
               { children }
             </TooltipContent>


### PR DESCRIPTION
Based on https://github.com/BrandwatchLtd/axiom-react/pull/738, I'm adding the `color` prop to the `TooltipContext` for `EllipsisTooltip`. This enables you to change the background between carbon and white.