### PR TITLE
feat(Icon): add drag handle icon

### DIFF
--- a/packages/axiom-components/src/Icon/Icon.js
+++ b/packages/axiom-components/src/Icon/Icon.js
@@ -45,6 +45,7 @@ export default class Icon extends Component {
       'dot-outline',
       'double-chevron-left',
       'double-chevron-right',
+      'drag',
       'duplicate',
       'ellipsis',
       'email',

--- a/packages/axiom-materials/src/icon_svgs/drag.svg
+++ b/packages/axiom-materials/src/icon_svgs/drag.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" height="16" width="16"><path d="M10.5 11a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm-5 0a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm5-5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm-5 0a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm5-5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm-5 0a2 2 0 1 1 0 4 2 2 0 0 1 0-4z" fill-rule="evenodd"/></svg>

--- a/packages/axiom-materials/src/icons.js
+++ b/packages/axiom-materials/src/icons.js
@@ -26,6 +26,7 @@ export default {
   'dot-outline': require('./icon_svgs/dot-outline.svg'),
   'double-chevron-left': require('./icon_svgs/double-chevron-left.svg'),
   'double-chevron-right': require('./icon_svgs/double-chevron-right.svg'),
+  'drag': require('./icon_svgs/drag.svg'),
   'duplicate': require('./icon_svgs/duplicate.svg'),
   'ellipsis': require('./icon_svgs/ellipsis.svg'),
   'email': require('./icon_svgs/email.svg'),


### PR DESCRIPTION
To be able to reorder a list by drag and drop we need a drag handle. 

Adding the icon provided by @lilybrandwatch in this PR

![image](https://user-images.githubusercontent.com/111471/64322410-d1aea700-cfc2-11e9-998f-c2ba2e809325.png)
