### PR TITLE
feat(ProgressButton): added flex to content wrapper

### DIFF
--- a/packages/axiom-components/src/Progress/ProgressButton.css
+++ b/packages/axiom-components/src/Progress/ProgressButton.css
@@ -16,3 +16,7 @@
     transform: translate(-50%, -50%) scale(1);
   }
 }
+
+.ax-progress-button__content {
+  display: flex;
+}


### PR DESCRIPTION
With ProgressButton, because we have an extra wrapper for the content that isn't flexed, adding items such as ButtonIcons means that they aren't centred (causing the button to render larger as well)
![image](https://user-images.githubusercontent.com/7304281/64443128-318f7580-d0c9-11e9-9f37-eb29079dcee8.png)

this fixes that:

![image](https://user-images.githubusercontent.com/7304281/64443157-3b18dd80-d0c9-11e9-9800-6f82a42fc0e0.png)
