### PR TITLE
MYB-2 update user avatar

### DIFF
--- a/packages/axiom-components/src/Avatar/Candytar.css
+++ b/packages/axiom-components/src/Avatar/Candytar.css
@@ -4,6 +4,11 @@
   margin-left: auto;
 }
 
+.ax-candytar__initials {
+  fill: var(--color-ui-white);
+  font-size: 0.9rem;
+}
+
 .ax-candytar--tiny-clanger {
   & .ax-candytar__body,
   & .ax-candytar__background {

--- a/packages/axiom-components/src/Avatar/Candytar.js
+++ b/packages/axiom-components/src/Avatar/Candytar.js
@@ -27,6 +27,11 @@ export default class Candytar extends Component {
       'luna-dust',
     ]),
     /**
+     * The User's initials to appear in the candytar.
+     * If no initials are supplied the silhouette will be shown by default.
+     */
+    initials: PropTypes.string,
+    /**
      * A function that can be passed to determine the colour of the candytar.
      * By default if no colour is provided it will randomly picker a colour
      * from the available options. Given function is called with an array of
@@ -39,26 +44,36 @@ export default class Candytar extends Component {
 
   static defaultProps = {
     picker: defaultPickerFn,
+    initials: '',
   };
 
   UNSAFE_componentWillMount = renderFilter
 
   render() {
-    const { picker, color = picker(availableColors), size } = this.props;
+    const { picker, color = picker(availableColors), size, initials } = this.props;
     const style = { height: size, width: size };
     const classes = classnames('ax-candytar', `ax-candytar--${color}`);
+    const userInitials = initials.slice(0, 2).toUpperCase();
 
     /* eslint-disable max-len */
+    const showSilhouette = (
+      <path
+          className="ax-candytar__body"
+          d="M16 20c-4 0-7-3-7-7s3-7 7-7 7 3 7 7-3 7-7 7zM6 28.5c1.7-3.8 5.6-6.5 10-6.5 4.5 0 8.3 2.7 10 6.5C23.4 30.7 20 32 16 32s-7.3-1.3-10-3.5z"
+          filter="url(#ax-candytar__filter)">
+      </path>
+    );
+
+    const showInitials = (
+      <text alignmentBaseline="middle" className="ax-candytar__initials" textAnchor="middle" x="50%" y="54%">{ userInitials }</text>
+    );
+    /* eslint-enable max-len */
+
     return (
       <svg className={ classes } style={ style } viewBox="0 0 32 32">
         <circle className="ax-candytar__background" cx="16" cy="16" r="16"></circle>
-        <path
-            className="ax-candytar__body"
-            d="M16 20c-4 0-7-3-7-7s3-7 7-7 7 3 7 7-3 7-7 7zM6 28.5c1.7-3.8 5.6-6.5 10-6.5 4.5 0 8.3 2.7 10 6.5C23.4 30.7 20 32 16 32s-7.3-1.3-10-3.5z"
-            filter="url(#ax-candytar__filter)"></path>
+        { initials ? showInitials : showSilhouette }
       </svg>
-
     );
-    /* eslint-enable max-len */
   }
 }

--- a/packages/axiom-components/src/Avatar/Candytar.js
+++ b/packages/axiom-components/src/Avatar/Candytar.js
@@ -47,7 +47,7 @@ export default class Candytar extends Component {
     initials: '',
   };
 
-  UNSAFE_componentWillMount = renderFilter
+  componentDidMount = renderFilter
 
   render() {
     const { picker, color = picker(availableColors), size, initials } = this.props;

--- a/packages/axiom-composites/src/UserMenu/UserMenu.js
+++ b/packages/axiom-composites/src/UserMenu/UserMenu.js
@@ -51,13 +51,15 @@ export default class UserMenu extends Component {
     const { children, firstName, lastName, email, imageSrc, onLogout, ...rest } = this.props;
     const color = stringToColor(email);
     const { axiomLanguage } = this.context;
+    const initials = `${firstName.charAt(0)}${lastName.charAt(0)}`;
+
 
     return (
       <Dropdown position="bottom" { ...rest }>
         <DropdownTarget>
           <Link data-ax-at={ atIds.UserMenu.activate }>
             <Avatar size="2rem" src={ imageSrc }>
-              <Candytar color={ color } size="2rem" />
+              <Candytar color={ color } initials={ initials } size="2rem" />
             </Avatar>
           </Link>
         </DropdownTarget>
@@ -78,7 +80,7 @@ export default class UserMenu extends Component {
 
                 <GridCell shrink>
                   <Avatar size="4.5rem" src={ imageSrc }>
-                    <Candytar color={ color } size="4.5rem" />
+                    <Candytar color={ color } initials={ initials } size="4.5rem" />
                   </Avatar>
                 </GridCell>
               </Grid>

--- a/site/components/Documentation/Resources/Components/Avatar.js
+++ b/site/components/Documentation/Resources/Components/Avatar.js
@@ -12,8 +12,8 @@ export default class Documentation extends Component {
       <DocumentationContent>
         <DocumentationShowCase centered>
           <Grid responsive={ false }>
-            <GridCell><Candytar size="3rem" /></GridCell>
-            <GridCell><Candytar size="3rem" /></GridCell>
+            <GridCell><Candytar initials="bw" size="3rem" /></GridCell>
+            <GridCell><Candytar initials="bw" size="3rem" /></GridCell>
             <GridCell><Avatar size="3rem" src="/assets/avatar.png" /></GridCell>
             <GridCell><Candytar size="3rem" /></GridCell>
             <GridCell><Candytar size="3rem" /></GridCell>


### PR DESCRIPTION
This PR does the following:

- Updates the Candytar component to accept and show the User's initials. If no initials are supplied then it shows the silhouette by default.
![Screen Shot 2019-09-18 at 10 01 01](https://user-images.githubusercontent.com/7721684/65134484-48549700-d9fc-11e9-918a-099204f4419a.png)

- Updates the UserMenu component to use the initials prop for the Candytar component so the User's initials are shown.
![Screen Shot 2019-09-18 at 10 00 04](https://user-images.githubusercontent.com/7721684/65134632-818d0700-d9fc-11e9-8dac-4e4e1a6367a6.png)

- Adds the initials prop to two of the Candytar components in the Avatar documentation example.
