### PR TITLE
feat(TextInput): Removed condition preventing "clear" icon AND input icon

### DIFF
--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -161,7 +161,7 @@ export default class TextInput extends Component {
                     name="cross"
                     onClick={ onClear } />
               }
-              { !showOnClear && showIcon && icon }
+              { showIcon && icon }
               <Base { ...rest }
                   Component="input"
                   baseRef={ inputRef }

--- a/packages/axiom-components/src/Form/TextInput.test.js
+++ b/packages/axiom-components/src/Form/TextInput.test.js
@@ -58,7 +58,7 @@ describe('TextInput', () => {
 
       it('renders when showing onClear', () => {
         const component = getComponent({ onClear: () => { }, value: 'foobar' },
-          <TextInputIcon name="twitter" />
+          <TextInputIcon align="left" name="twitter" />
         );
         const tree = component.toJSON();
         expect(tree).toMatchSnapshot();
@@ -73,7 +73,7 @@ describe('TextInput', () => {
         expect(tree).toMatchSnapshot();
       });
 
-      it('does not render when showing onClear', () => {
+      it('renders when showing onClear', () => {
         const component = getComponent({ onClear: () => { }, value: 'foobar' },
           <TextInputIcon name="twitter" />
         );

--- a/packages/axiom-components/src/Form/__snapshots__/TextInput.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/TextInput.test.js.snap
@@ -86,6 +86,25 @@ exports[`TextInput renders TextInputIcon when left aligned renders when showing 
           />
         </a>
       </span>
+      <span
+        className="ax-input__icon ax-input__icon--align-left"
+      >
+        <svg
+          className="ax-icon ax-icon--twitter"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "",
+            }
+          }
+          style={
+            Object {
+              "height": "1rem",
+              "width": "1rem",
+            }
+          }
+          viewBox="0 0 16 16"
+        />
+      </span>
       <input
         className="ax-input"
         onBlur={[Function]}
@@ -150,7 +169,7 @@ exports[`TextInput renders TextInputIcon when right aligned does not render when
 </div>
 `;
 
-exports[`TextInput renders TextInputIcon when right aligned does not render when showing onClear 1`] = `
+exports[`TextInput renders TextInputIcon when right aligned renders when showing onClear 1`] = `
 <div
   className="ax-input__container ax-space--x4"
 >
@@ -183,6 +202,25 @@ exports[`TextInput renders TextInputIcon when right aligned does not render when
             viewBox="0 0 16 16"
           />
         </a>
+      </span>
+      <span
+        className="ax-input__icon ax-input__icon--align-right"
+      >
+        <svg
+          className="ax-icon ax-icon--twitter"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "",
+            }
+          }
+          style={
+            Object {
+              "height": "1rem",
+              "width": "1rem",
+            }
+          }
+          viewBox="0 0 16 16"
+        />
       </span>
       <input
         className="ax-input"


### PR DESCRIPTION
Currently using the `TextInputIcon` **with** the `onClear` property on `TextInput` isn't possible.
This PR is removing this limitation. As a result **if** someone wrote code as follows:

```js
<TextInput onClear={ () => {} }>
  <TextInputIcon name="magnify-glass" />
</TextInput>
```

this would result in the input looking like this:

![Screenshot 2019-09-26 at 09 32 56](https://user-images.githubusercontent.com/1510613/65667993-2df46c00-e041-11e9-895e-7688f2235ef0.png)

The code can be fixed by explicitly passing the `align` property to `TextInputIcon` with a value of `left`:

```js
<TextInput onClear={ () => {} }>
  <TextInputIcon name="magnify-glass" align="left" />
</TextInput>
```

As a result the input is going to look like this:

![Screenshot 2019-09-26 at 09 33 11](https://user-images.githubusercontent.com/1510613/65668044-482e4a00-e041-11e9-97eb-4be595c4732c.png)

**As the combination of `onClear` and `TextInputIcon` isn't possible at the moment I don't expect anyone to be affect **but** just to be on the safe side I made this a breaking change. There won't be any JavaScript errors happening but rather the UI wouldn't look perfect.**

I also noticed the snapshot for `TextInput > renders TextInputIcon > when left aligned > renders when showing onClear` was actually wrong.

Below you can find the body of the commit message

-----

BREAKING CHANGE: This is going to cause some design "glitches" where a TextInput
is used with the "onClear" property AND a TextInputIcon as a child WITHOUT the
"align" property being set to "left".

The following code examples are affected:

TextInputIcon with no "align" property:
In this case previously the "TextInputIcon" wouldn't be visible but with this
change is going to be visible and aligned on the right.
```js
<TextInput onClear={ () => {} }>
  <TextInputIcon name="magnify-glass" />
</TextInput>
```

You can fix this by adding the "align" property to the TextInputIcon
```js
<TextInput onClear={ () => {} }>
  <TextInputIcon name="magnify-glass" align="left" />
</TextInput>
```

Another affected example would be this:
Same as in the previous example the "TextInputIcon" wouldn't be visible but with
this change it would be visible and aligned on the right.
```js
<TextInput onClear={ () => {} }>
  <TextInputIcon name="magnify-glass" align="right" />
</TextInput>
```

Same as before you can fix this by changing the "align" property on the
"TextInputIcon" to "left":
```js
<TextInput onClear={ () => {} }>
  <TextInputIcon name="magnify-glass" align="left" />
</TextInput>
```