### PR TITLE
feat(Dialog): Adds new large and fullscreen options.

### DIFF
--- a/packages/axiom-components/src/Dialog/Dialog.css
+++ b/packages/axiom-components/src/Dialog/Dialog.css
@@ -36,7 +36,12 @@
   flex: 0 1 auto;
 }
 
-.ax-dialog--fullscreen {
+.ax-dialog--fullscreen,
+.ax-dialog--large {
   width: 100vw;
   height: 100vh;
+}
+
+.ax-dialog--fullscreen {
+  border-radius: 0;
 }

--- a/packages/axiom-components/src/Dialog/Dialog.js
+++ b/packages/axiom-components/src/Dialog/Dialog.js
@@ -13,8 +13,6 @@ export default class Dialog extends Component {
     className: PropTypes.string,
     /** Stops the dialog closing when the mask is clicked */
     closeOnOverlayClick: PropTypes.bool,
-    /** Control for the Dialog stretching to the windows size */
-    fullscreen: PropTypes.bool,
     /** Visibility toggle for the Dialog */
     isOpen: PropTypes.bool.isRequired,
     /** Callback for closing the Dialog by clicking on the overlay */
@@ -29,9 +27,11 @@ export default class Dialog extends Component {
     /** Theme applied to the overlay */
     overlayTheme: PropTypes.oneOf(['day', 'night']),
     /** Padding around the modal */
-    padding: PropTypes.oneOf(['x6', 'x8', 'x12', 'x16']),
+    padding: PropTypes.oneOf(['x0', 'x6', 'x8', 'x12', 'x16']),
     /** Toggle if the Dialog should be closed by pressing Esc */
     shouldCloseOnEsc: PropTypes.bool,
+    /** Provides defaults for dialog and modal size*/
+    size: PropTypes.oneOf(['large', 'fullscreen']),
     /** Theme of the dialog */
     theme: PropTypes.oneOf(['day', 'night']),
     /** Custom width for Dialog */
@@ -59,26 +59,29 @@ export default class Dialog extends Component {
       children,
       className,
       closeOnOverlayClick,
-      fullscreen,
       onRequestClose,
       overlayShade,
       overlayTheme,
       padding,
+      size,
       theme,
       width,
       ...rest
     } = this.props;
 
     const classes = classnames('ax-dialog', {
-      'ax-dialog--fullscreen': fullscreen,
+      'ax-dialog--fullscreen': size === 'fullscreen',
+      'ax-dialog--large': size === 'large',
     }, className);
+
+    const modalPadding = size === 'fullscreen' ? 'x0' : padding;
 
     return (
       <Modal { ...rest }
           onOverlayClick={ closeOnOverlayClick ? onRequestClose : null }
           overlayShade={ overlayShade }
           overlayTheme={ overlayTheme }
-          padding={ padding }>
+          padding={ modalPadding }>
         <Base className={ classes } style={ { width } } theme={ theme }>
           { children }
         </Base>

--- a/packages/axiom-components/src/Modal/Modal.js
+++ b/packages/axiom-components/src/Modal/Modal.js
@@ -27,7 +27,7 @@ export default class Modal extends Component {
       'shade-4',
     ]),
     overlayTheme: PropTypes.oneOf(['day', 'night']),
-    padding: PropTypes.oneOf(['x6', 'x8', 'x12', 'x16']),
+    padding: PropTypes.oneOf(['x0', 'x6', 'x8', 'x12', 'x16']),
     shouldCloseOnEsc: PropTypes.bool,
   };
 

--- a/site/components/Documentation/Resources/Components/Dialog.js
+++ b/site/components/Documentation/Resources/Components/Dialog.js
@@ -31,8 +31,7 @@ export default class Documentation extends Component {
         <DocumentationShowCase hidePreview>
           <Dialog
               isOpen
-              onRequestClose={ (setValue) => setValue('Dialog', 'isOpen', false) }
-              width="50rem">
+              onRequestClose={ (setValue) => setValue('Dialog', 'isOpen', false) }>
             <DialogHeader>
               <Heading textSize="headtitle">Dialog Title</Heading>
             </DialogHeader>


### PR DESCRIPTION
Add size prop with 2 options to allow dialog to cover w…hole screen and cover with padding.

BREAKING CHANGE: Usage of the fullscreen property on the Dialog component will now have no effect. You can recreate the previous fullscreen mode by passing `size=large` e.g.
```
<Dialog size="large" />
```
Size fullscreen will remove the padding previously found in fullscreen mode.

large size
<img width="1680" alt="Screen Shot 2019-10-10 at 10 05 48" src="https://user-images.githubusercontent.com/3940567/66554851-9a915f80-eb45-11e9-996b-77c40331ae76.png">

fullscreen size
<img width="1680" alt="Screen Shot 2019-10-10 at 10 05 27" src="https://user-images.githubusercontent.com/3940567/66554886-a4b35e00-eb45-11e9-87fa-0477d14c467b.png">
