### PR TITLE
feat(TextInput): Adding a "labelSpace" property

### DIFF
--- a/packages/axiom-components/src/Form/InputWrapper.js
+++ b/packages/axiom-components/src/Form/InputWrapper.js
@@ -22,6 +22,7 @@ export default class InputWrapper extends Component {
     isTarget: PropTypes.bool,
     isValid: PropTypes.bool,
     label: PropTypes.node,
+    labelSpace: PropTypes.oneOf(['x0', 'x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x8']),
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     space: PropTypes.string,
     style: PropTypes.string,
@@ -33,11 +34,12 @@ export default class InputWrapper extends Component {
   static defaultProps = {
     size: 'medium',
     space: 'x4',
+    labelSpace: 'x2',
     inlineLabel: false,
   };
 
   render() {
-    const { children, inlineLabel, disabled, hasFocus, invalid, isTarget, isValid, label, size, space, style, usageHint, usageHintPosition, valid, ...rest } = this.props;
+    const { children, inlineLabel, disabled, hasFocus, invalid, isTarget, isValid, label, labelSpace, size, space, style, usageHint, usageHintPosition, valid, ...rest } = this.props;
     const classes = classnames('ax-input__wrapper', {
       'ax-input__wrapper--target': isTarget,
       'ax-input__wrapper--inline': inlineLabel,
@@ -52,7 +54,7 @@ export default class InputWrapper extends Component {
       'ax-input__icon-container--invalid': invalid || isValid === false,
     });
 
-    const inputWrapperSpace = inlineLabel ? 'x0' : 'x2';
+    const inputWrapperSpace = inlineLabel ? 'x0' : labelSpace;
 
     return (
       <Base { ...rest }

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -30,6 +30,8 @@ export default class TextInput extends Component {
     isTarget: PropTypes.bool,
     /** Descriptive label that is placed with the input field */
     label: PropTypes.string,
+    /** Vertical margin between label and input */
+    labelSpace: PropTypes.oneOf(['x0', 'x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x8']),
     /** Handler for when the input field is blurred */
     onBlur: PropTypes.func,
     /** Handler for changing the input field */
@@ -112,6 +114,7 @@ export default class TextInput extends Component {
       isInProgress,
       isTarget,
       label,
+      labelSpace,
       onClear,
       patterns,
       required,
@@ -149,6 +152,7 @@ export default class TextInput extends Component {
                 isTarget={ isTarget }
                 isValid={ isValid }
                 label={ label }
+                labelSpace={ labelSpace }
                 size={ size }
                 space={ space }
                 style={ style }


### PR DESCRIPTION
This is adding a `labelSpace` property to the `TextInput` component so you can customize the margin between the Label and the Input.
It provides any of the `x0-8` options. Currently it is hard-coded to `x2`.

Note: If `inlineLabel` is set we do not provide this option.

![Screenshot 2019-10-16 at 15 17 57](https://user-images.githubusercontent.com/1510613/66922908-3cbeb500-f028-11e9-8089-195e9ef85ad4.png)
