### PR TITLE
feat(Separator): allow className prop

### DIFF
--- a/packages/axiom-components/src/Separator/Separator.js
+++ b/packages/axiom-components/src/Separator/Separator.js
@@ -7,6 +7,7 @@ import './Separator.css';
 export default class Separator extends Component {
   static propTypes = {
     borderStyle: PropTypes.oneOf(['solid', 'dotted']),
+    className: PropTypes.string,
     direction: PropTypes.oneOf(['horizontal', 'vertical']),
   };
 
@@ -16,8 +17,12 @@ export default class Separator extends Component {
   };
 
   render() {
-    const { borderStyle, direction, ...rest } = this.props;
-    const classes = classnames('ax-separator', `ax-separator--${borderStyle}`, `ax-separator--${direction}`);
+    const { borderStyle, direction, className, ...rest } = this.props;
+    const classes = classnames('ax-separator',
+      `ax-separator--${borderStyle}`,
+      `ax-separator--${direction}`,
+      className
+    );
 
     return (
       <Base

--- a/packages/axiom-components/src/Separator/Separator.test.js
+++ b/packages/axiom-components/src/Separator/Separator.test.js
@@ -14,6 +14,12 @@ describe('Separator', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('accepts className prop', () => {
+    const component = getComponent({ className: 'test' });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   describe('renders with style', () => {
     ['solid', 'dotted'].forEach((borderStyle) => {
       it(borderStyle, () => {

--- a/packages/axiom-components/src/Separator/__snapshots__/Separator.test.js.snap
+++ b/packages/axiom-components/src/Separator/__snapshots__/Separator.test.js.snap
@@ -6,6 +6,12 @@ exports[`Separator renders with defaultProps 1`] = `
 />
 `;
 
+exports[`Separator accepts className prop 1`] = `
+<hr
+  className="ax-separator ax-separator--solid ax-separator--horizontal test ax-space--x0"
+/>
+`;
+
 exports[`Separator renders with direction horizontal 1`] = `
 <hr
   className="ax-separator ax-separator--solid ax-separator--horizontal ax-space--x0"


### PR DESCRIPTION
Allows the `Separator` component to use `className` prop.

I currently have a situation where I have the following: 
![image](https://user-images.githubusercontent.com/17451516/67222063-7c204380-f424-11e9-8392-8f93a3a80d61.png)

But need this:
![image](https://user-images.githubusercontent.com/17451516/67222073-84787e80-f424-11e9-8392-f830bb1e04af.png)

Where the separator color changes based on parent's focused state. I could override the ax class but felt like a class on the separator itself was cleaner.
