### PR TITLE
fix(Candytar): Initials baseline alignment

### DIFF
--- a/packages/axiom-components/src/Avatar/Candytar.js
+++ b/packages/axiom-components/src/Avatar/Candytar.js
@@ -65,7 +65,7 @@ export default class Candytar extends Component {
     );
 
     const showInitials = (
-      <text alignmentBaseline="middle" className="ax-candytar__initials" textAnchor="middle" x="50%" y="54%">{ userInitials }</text>
+      <text className="ax-candytar__initials" dominantBaseline="middle" textAnchor="middle" x="50%" y="54%">{ userInitials }</text>
     );
     /* eslint-enable max-len */
 


### PR DESCRIPTION
The candytar had alignment issues with the initials when viewed in Firefox. 

Before (Firefox)
![image](https://user-images.githubusercontent.com/7532495/67754751-e5a8df00-fa2e-11e9-8997-ad855506a796.png)
After (Firefox)
![image](https://user-images.githubusercontent.com/7532495/67754763-ea6d9300-fa2e-11e9-8f0a-93ad2c7d3ef2.png)
After (Chrome) 
![image](https://user-images.githubusercontent.com/7532495/67754923-2bfe3e00-fa2f-11e9-9693-b888fbac35a6.png)
