### PR TITLE
fix: fix issue where popper would completely freeze the browser tab

### DIFF
--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -16,7 +16,7 @@
     "element-closest": "^2.0.2",
     "lodash.omit": "^4.5.0",
     "luxon": "^1.12.0",
-    "popper.js": "^1.12.5",
+    "popper.js": "^1.16.0",
     "prop-types": "^15.6.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8931,10 +8931,10 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-popper.js@^1.12.5:
-  version "1.12.9"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
-  integrity sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM=
+popper.js@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"
+  integrity sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==
 
 portfinder@^1.0.9:
   version "1.0.13"


### PR DESCRIPTION
Popper was updated to a 1.12.9 in a recent axiom update which causes issues where, on a small window, opening up a dropdown (or trying to) could completely freeze the browser tab and make it unresponsive

You can replicate the bug in the documentation site by shrinking the window down, opening up a Dropdown and scrolling up and down (doesn’t happen 100% of the time so keep trying)