### PR TITLE
Popper fix

### DIFF
--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -16,10 +16,10 @@
     "element-closest": "^2.0.2",
     "lodash.omit": "^4.5.0",
     "luxon": "^1.12.0",
-    "popper.js": "1.12.5",
     "prop-types": "^15.6.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-popper": "^1.3.6",
     "react-transition-group": "^2.3.0",
     "resize-observer-polyfill": "^1.5.1",
     "uuid": "^3.3.2"

--- a/packages/axiom-components/src/Base/Base.js
+++ b/packages/axiom-components/src/Base/Base.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import omit from 'lodash.omit';
 import classnames from 'classnames';
 import { importCssVariables } from '@brandwatch/axiom-materials';
 import './globals.css';
@@ -209,7 +210,7 @@ export default class Base extends Component {
     }
 
     return (
-      <Component { ...rest } className={ classes } ref={ baseRef } />
+      <Component { ...omit(rest, ['inputRef']) } className={ classes } ref={ baseRef } />
     );
   }
 }

--- a/packages/axiom-components/src/Context/Context.js
+++ b/packages/axiom-components/src/Context/Context.js
@@ -8,6 +8,7 @@ import './Context.css';
 export default class Context extends Component {
   static propTypes = {
     arrowRef: PropTypes.func,
+    arrowStyle: PropTypes.object,
     children: PropTypes.node,
     className: PropTypes.string,
     color: PropTypes.oneOf(['success', 'warning', 'error', 'info', 'carbon', 'white']),
@@ -20,10 +21,12 @@ export default class Context extends Component {
     maxHeight: '30rem',
     position: 'top',
     width: '14.5rem',
+    arrowStyle: {},
   };
 
   render() {
     const {
+      arrowStyle,
       className,
       arrowRef,
       children,
@@ -40,10 +43,11 @@ export default class Context extends Component {
     const content = () => <div className="ax-context__content" style={ { maxHeight } }>
       { children }
     </div>;
+
     return (
       <Base theme="day" { ...rest } className={ classes } style={ { width } }>
         { arrowRef ?
-          <Tip arrowRef={ arrowRef } color={ color } direction={ position } size="small">
+          <Tip arrowRef={ arrowRef } arrowStyle={ arrowStyle } color={ color } direction={ position } size="small" >
             { content() }
           </Tip> :
         content()

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -106,6 +106,7 @@ export default class TextInput extends Component {
 
   render() {
     const {
+      baseRef,
       children,
       disabled,
       error,
@@ -143,7 +144,7 @@ export default class TextInput extends Component {
           required={ required }
           value={ value }>
         { (isValid) =>
-          <Base className="ax-input__container" space={ space }>
+          <Base baseRef={ baseRef } className="ax-input__container" space={ space }>
             <InputWrapper
                 disabled={ disabled }
                 hasFocus={ hasFocus }

--- a/packages/axiom-components/src/Position/Position.css
+++ b/packages/axiom-components/src/Position/Position.css
@@ -3,19 +3,19 @@
   z-index: var(--z-index-position);
 }
 
-.ax-position--arrow[x-placement*='bottom'] {
+.ax-position--arrow[data-popper-placement*='bottom'] {
   margin-top: calc((var(--cmp-context-tip-edge-to-edge) * 0.5) + var(--spacing-grid-size--x2));
 }
 
-.ax-position--arrow[x-placement*='top'] {
+.ax-position--arrow[data-popper-placement*='top'] {
   margin-bottom: calc((var(--cmp-context-tip-edge-to-edge) * 0.5) + var(--spacing-grid-size--x2));
 }
 
-.ax-position--arrow[x-placement*='left'] {
+.ax-position--arrow[data-popper-placement*='left'] {
   margin-right: calc((var(--cmp-context-tip-edge-to-edge) * 0.5) + var(--spacing-grid-size--x2));
 }
 
-.ax-position--arrow[x-placement*='right'] {
+.ax-position--arrow[data-popper-placement*='right'] {
   margin-left: calc((var(--cmp-context-tip-edge-to-edge) * 0.5) + var(--spacing-grid-size--x2));
 }
 

--- a/packages/axiom-components/src/Position/Position.js
+++ b/packages/axiom-components/src/Position/Position.js
@@ -1,14 +1,17 @@
 import PropTypes from 'prop-types';
 import React, { Component, cloneElement } from 'react';
-import ReactDOM from 'react-dom';
-import popperJS from 'popper.js';
 import omit from 'lodash.omit';
+import { Manager, Reference, Popper } from 'react-popper';
 import classnames from 'classnames';
 import { findComponent } from '@brandwatch/axiom-utils';
 import Portal from '../Portal/Portal';
 import { PositionSourceRef } from './PositionSource';
 import { PositionTargetRef } from './PositionTarget';
-import { placementToPosition, positionToPlacement, getPlacementFlipOrder } from './_utils';
+import {
+  positionToPlacement,
+  getPlacementFlipOrder,
+  placementToPosition,
+} from './_utils';
 import './Position.css';
 
 /* eslint-disable react/no-find-dom-node */
@@ -26,10 +29,7 @@ export default class Position extends Component {
      * only PositionSource and PositionTarget or just a PositionSource
      * in the case of a given reference!
      */
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.array,
-    ]).isRequired,
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.array]).isRequired,
     /** Class name to be appended to the element */
     className: PropTypes.string,
     /**
@@ -48,11 +48,6 @@ export default class Position extends Component {
      * function is called when clicked.
      */
     onMaskClick: PropTypes.func,
-    /**
-     * Optional handler that is called, with the new position, when PositionSource
-     * has been positioned.
-     */
-    onPositionChange: PropTypes.func,
     /**
      * Controls the starting position around PositionTarget in which the
      * PositionSource will attempt to be placed. If that position is not available
@@ -77,150 +72,95 @@ export default class Position extends Component {
     flip: 'clockwise',
     offset: 'middle',
     position: 'top',
-    showArrow:  false,
+    showArrow: false,
   };
 
-  constructor(props) {
-    super(props);
-    this.handleOnCreate = this.handleOnCreate.bind(this);
-    this.handleOnUpdate = this.handleOnUpdate.bind(this);
-    this.state = {
-      placement: positionToPlacement(props.position, props.offset),
-    };
-  }
-
-  componentDidMount() {
-    if (this._content) {
-      this._popper = this.createPopper();
-    }
-  }
-
-  componentDidUpdate() {
-    const { enabled, isVisible, position, offset } = this.props;
-
-    if (enabled && isVisible) {
-      if (!this._popper) {
-        this._popper = this.createPopper();
-      } else {
-        this._popper.options.placement = positionToPlacement(position, offset);
-        this._popper.update();
-      }
-    } else if (this._popper) {
-      this.destroyPopper();
-    }
-  }
-
-  componentWillUnmount() {
-    this.destroyPopper();
-  }
-
-  createPopper() {
-    const { boundariesElement, flip, showArrow, reference } = this.props;
-    const { placement } = this.state;
-
-    return new popperJS(reference || this._target, this._content, {
-      onCreate: this.handleOnCreate,
-      onUpdate: this.handleOnUpdate,
-      placement,
-      modifiers: {
-        arrow: {
-          enabled: showArrow,
-          element: this._arrow,
-        },
-        flip: {
-          behavior: getPlacementFlipOrder(placement, flip),
-        },
-        inner: {
-          enabled: false,
-        },
-        offset: {
-          enabled: false,
-        },
-        preventOverflow: {
-          boundariesElement,
-        },
-      },
-    });
-  }
-
-  destroyPopper() {
-    if (this._popper) {
-      this._popper.destroy();
-    }
-
-    delete this._popper;
-    delete this._arrow;
-    delete this._content;
-
-    const placement = positionToPlacement(this.props.position, this.props.offset);
-    if (placement !== this.state.placement) {
-      this.setState({ placement });
-    }
-  }
-
-  handleOnCreate(popper) {
-    const { onPositionChange } = this.props;
-
-    this.handleOnUpdate(popper);
-
-    if (onPositionChange) {
-      onPositionChange(popper.placement);
-    }
-  }
-
-  handleOnUpdate({ placement }) {
-    const { onPositionChange } = this.props;
-    const { placement: statePlacement } = this.state;
-
-    if (statePlacement !== placement) {
-      this.setState({ placement });
-
-      if (onPositionChange) {
-        onPositionChange(placement);
-      }
-    }
-  }
-
   render() {
-    const { children, className, enabled, isVisible, onMaskClick, showArrow, reference, ...rest } = this.props;
-    const { placement } = this.state;
-    const [ position ] = placementToPosition(placement);
+    const {
+      boundariesElement,
+      children,
+      className,
+      enabled,
+      isVisible,
+      flip,
+      onMaskClick,
+      reference,
+      showArrow,
+      position: initialPosition,
+      offset,
+      ...rest
+    } = this.props;
+    const classes = classnames(
+      'ax-position',
+      {
+        'ax-position--arrow': showArrow,
+      },
+      className
+    );
 
-    const classes = classnames('ax-position', {
-      'ax-position--arrow': showArrow,
-    }, className);
+    const props = omit(rest, ['flip', 'offset', 'onPositionChange']);
 
-    const props = omit(rest, [
-      'flip',
-      'offset',
-      'position',
-      'onPositionChange',
-    ]);
+    const placement = positionToPlacement(initialPosition, offset);
 
-    return [
-      !reference && cloneElement(findComponent(children, PositionTargetRef), {
-        ref: (target) => this._target = ReactDOM.findDOMNode(target),
-      }),
-      enabled && isVisible ? (
-        <Portal { ...props } key="portal">
-          <div>
-            { onMaskClick && (
-              <div className="ax-position__mask" onClick={ onMaskClick } />
-            ) }
+    return (
+      <Manager>
+        { !reference && (
+          <Reference>
+            { ({ ref }) =>
+              cloneElement(findComponent(children, PositionTargetRef), {
+                baseRef: ref,
+                inputRef: ref,
+              })
+            }
+          </Reference>
+        ) }
+        { enabled && isVisible && <Portal { ...props } key="portal">
+          <Popper
+              modifiers={ {
+                preventOverflow: {
+                  boundariesElement,
+                },
+                flip: {
+                  behavior: getPlacementFlipOrder(placement, flip),
+                },
+              } }
+              placement={ placement }
+              referenceElement={ reference }>
+            {
+                ({ placement, ref, style, arrowProps }) => {
+                  let position = initialPosition;
+                  if (placement) {
+                    position = placementToPosition(placement)[0];
+                  }
 
-            <div className={ classes } ref={ (el) => this._content = el }>
-              {
-                cloneElement(findComponent(children, PositionSourceRef), {
-                  arrowRef: showArrow
-                    ? (arrow) => this._arrow = ReactDOM.findDOMNode(arrow)
-                    : undefined,
-                  position,
-                })
+                  return (
+                    <div
+                        className={ classes }
+                        data-popper-placement={ placement }
+                        ref={ ref }
+                        style={ style }>
+                      <div>
+                        { onMaskClick && (
+                          <div
+                              className="ax-position__mask"
+                              onClick={ onMaskClick }/>
+                        ) }
+                        { cloneElement(
+                          findComponent(children, PositionSourceRef),
+                          {
+                            arrowRef: showArrow ? arrowProps.ref : undefined,
+                            position,
+                            arrowStyle: arrowProps.style,
+                          }
+                        ) }
+                      </div>
+                    </div>
+                  );
+                }
               }
-            </div>
-          </div>
-        </Portal>
-      ) : null,
-    ];
+          </Popper>
+        </Portal> }
+      </Manager>
+    );
   }
 }

--- a/packages/axiom-components/src/Tip/Tip.js
+++ b/packages/axiom-components/src/Tip/Tip.js
@@ -26,11 +26,11 @@ export default class Tip extends Component {
     shadow: true,
     direction: 'top',
     size: 'medium',
+    arrowStyle: {},
   };
 
   getArrowStyles = () => {
     const { position, direction } = this.props;
-
     switch (direction) {
     case 'top':
     case 'bottom':
@@ -42,7 +42,7 @@ export default class Tip extends Component {
   };
 
   render() {
-    const { arrowRef, color, direction, position, children, shadow, size, ...rest } = this.props;
+    const { arrowRef, arrowStyle, color, direction, position, children, shadow, size, ...rest } = this.props;
 
     const classes = classnames(`ax-tip--${direction}`, {
       [`ax-tip--${color}`]: color,
@@ -53,10 +53,12 @@ export default class Tip extends Component {
       [`ax-tip__arrow--${size}`]: size,
     });
 
+    const arrowStyles = Object.assign({}, position ? this.getArrowStyles() : {}, arrowStyle);
+
     return (
       <Base className={ classes } { ...rest }>
-        <span className={ arrowClasses } ref={ arrowRef } style={ position ? this.getArrowStyles() : {} } />
-        <Base className="ax-tip__content">{ children }</Base>
+        <span className={ arrowClasses } ref={ arrowRef } style={ arrowStyles } />
+        <Base className="ax-tip__content" style={ arrowStyle }>{ children }</Base>
       </Base>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,13 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.2.tgz#111a78002a5c25fc8e3361bedc9529c696b85a6a"
+  integrity sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.0.0-beta.36":
   version "7.0.0-beta.36"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.36.tgz#02e903de5d68bd7899bce3c5b5447e59529abb00"
@@ -3250,6 +3257,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-context@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
+  integrity sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
+  dependencies:
+    gud "^1.0.0"
+    warning "^4.0.3"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5307,6 +5322,11 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 handle-thing@^1.2.5:
   version "1.2.5"
@@ -8931,10 +8951,10 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-popper.js@1.12.5:
-  version "1.12.5"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.5.tgz#229e4dea01629e1f1a1e26991ffade5024220fa6"
-  integrity sha512-6R2eXIy1xYukMNutoD+y/Gj0IpjEQhivyZonm5Vz0Fp8jdc7kvheKCvpM/t+PxqKb7VbLVnvPVEdTyslEb7f6w==
+popper.js@^1.14.4:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"
+  integrity sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==
 
 portfinder@^1.0.9:
   version "1.0.13"
@@ -9782,7 +9802,7 @@ prop-types@^15.5.8:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.2:
+prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10083,6 +10103,18 @@ react-is@^16.8.1, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-popper@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.6.tgz#32122f83af8fda01bdd4f86625ddacaf64fdd06d"
+  integrity sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    create-react-context "^0.3.0"
+    popper.js "^1.14.4"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"
@@ -10403,6 +10435,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -12173,6 +12210,11 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -12607,6 +12649,13 @@ warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
   integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.2, warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Breaking Change.

A recent upgrade of `Popper.js` introduced a [bug](814) which created an infinite loop, crashing the browser. This was caused by and highlighted a flaw in our implementation, we had two sources of truth for `placement` local state and Popper.js. 

Position's local state was needed to update our component Arrow when the popper changed it's orientation as a user scrolled or the window size changed. This state was updated by hooking into Poppers.js callback. Attempting to remove this local state caused a few difficulties and would mean we would have to continue to write more imperative code to manipulate the arrow DOM.

This proposed solution replaces `Popper.js` with [react-popper](https://github.com/FezVrasta/react-popper). `react-poppper` provides a declarative API wrapper around poppper. This allows us to hook into the `placement` change with eas, using the provided render prop. Another benefit of this change is that we can delete our code that bridge the gap between DOM and React.

Removes the `onPositionChange` which I can see [no use](https://github.com/search?q=org%3ABrandwatchLtd+onPositionChange&type=Code) of in all of Brandwatch.

Things that are broke
* DataPicker - input/base ref issue
* usageHint - misaligned
* Tip - arrow styles?