### PR TITLE
Revert "fix(Validate): Update docs example to use a dymanic required"

### DIFF
--- a/packages/axiom-composites/src/ChangePasswordDialog/ChangePasswordDialog.js
+++ b/packages/axiom-composites/src/ChangePasswordDialog/ChangePasswordDialog.js
@@ -13,8 +13,6 @@ import {
   Heading,
   ProgressButton,
   Paragraph,
-  RadioButton,
-  RadioButtonGroup,
 } from '@brandwatch/axiom-components';
 import { translate } from '@brandwatch/axiom-localization';
 import ConfirmPasswordInput from '../FormInputs/ConfirmPasswordInput';
@@ -71,7 +69,6 @@ export default class ChangePasswordDialog extends Component {
       confirmPassword: '',
       currentPassword: '',
       validationError: '',
-      isNewPassword: false,
       newPassword: '',
     };
   }
@@ -100,7 +97,6 @@ export default class ChangePasswordDialog extends Component {
     const {
       confirmPassword,
       currentPassword,
-      isNewPassword,
       newPassword,
       validationError,
     } = this.state;
@@ -128,39 +124,21 @@ export default class ChangePasswordDialog extends Component {
           ) }
 
           <DialogBody>
-            <RadioButtonGroup>
-              <RadioButton
-                  checked={ isNewPassword }
-                  onChange={ () => this.setState({ isNewPassword: true }) }>
-                Set new Password
-              </RadioButton>
-              <RadioButton
-                  checked={ !isNewPassword }
-                  onChange={ () => this.setState({ isNewPassword: false }) }>
-                Don't Set new Password
-              </RadioButton>
-            </RadioButtonGroup>
             <CurrentPasswordInput
                 data-ax-at={ atIds.ChangePassword.currentPassword }
-                disabled={ !isNewPassword }
                 invalid={ isCurrentPasswordInvalid }
                 onChange={ (e) => this.setState({ currentPassword: e.target.value }) }
-                required={ isNewPassword }
                 value={ currentPassword } />
 
             <NewPasswordInput
                 data-ax-at={ atIds.ChangePassword.newPassword }
-                disabled={ !isNewPassword }
                 onChange={ (e) => this.setState({ newPassword: e.target.value }) }
-                required={ isNewPassword }
                 value={ newPassword } />
 
             <ConfirmPasswordInput
                 data-ax-at={ atIds.ChangePassword.confirmPassword }
-                disabled={ !isNewPassword }
                 onChange={ (e) => this.setState({ confirmPassword: e.target.value }) }
                 passwordValue={ newPassword }
-                required={ isNewPassword }
                 value={ confirmPassword } />
 
             <ButtonGroup textRight>

--- a/packages/axiom-composites/src/FormInputs/ConfirmPasswordInput.js
+++ b/packages/axiom-composites/src/FormInputs/ConfirmPasswordInput.js
@@ -35,6 +35,7 @@ export default class ConfirmPasswordInput extends Component {
           error={ () => t('Sorry, your password confirmation doesn\'t match', axiomLanguage) }
           label={ t('Confirm new password', axiomLanguage) }
           patterns={ [(value) => value === passwordValue] }
+          required
           space="x8"
           type="password"
           value={ value } />

--- a/packages/axiom-composites/src/FormInputs/CurrentPasswordInput.js
+++ b/packages/axiom-composites/src/FormInputs/CurrentPasswordInput.js
@@ -29,6 +29,7 @@ export default class CurrentPasswordInput extends Component {
       <TextInput { ...rest }
           invalid={ invalid }
           label={ t('Enter current password', axiomLanguage) }
+          required
           space="x8"
           type="password"
           value={ value } />

--- a/packages/axiom-composites/src/FormInputs/NewPasswordInput.js
+++ b/packages/axiom-composites/src/FormInputs/NewPasswordInput.js
@@ -56,13 +56,12 @@ export default class NewPasswordInput extends Component {
   };
 
   static propTypes = {
-    required: PropTypes.bool,
     value: PropTypes.string.isRequired,
   };
 
   render() {
     const { axiomLanguage } = this.context;
-    const { required, value, ...rest } = this.props;
+    const { value, ...rest } = this.props;
 
     const validations = [{
       error: t('at least 8 characters', axiomLanguage),
@@ -96,8 +95,8 @@ export default class NewPasswordInput extends Component {
       <Validate
           error={ getValidationError }
           key="newPassword"
-          patterns={ required ? validations.map(({ pattern }) => pattern) : [] }
-          required={ required }
+          patterns={ validations.map(({ pattern }) => pattern) }
+          required
           value={ value }>
         { (valid, hasMetRequired, hasMetPattern) => [
           <TextInput { ...rest }


### PR DESCRIPTION
This reverts commit d6c6067

Looks like I changed a base api component thinking it was just and example used in the docs. 🤪

ChangePasswordDialog is used in accounts.brandwatch and my brandwatch this change was breaking them when they updated axiom. 