### PR TITLE
fix(Candytar) baseline alignment for initials

### DIFF
--- a/packages/axiom-components/src/Avatar/Candytar.js
+++ b/packages/axiom-components/src/Avatar/Candytar.js
@@ -65,7 +65,7 @@ export default class Candytar extends Component {
     );
 
     const showInitials = (
-      <text className="ax-candytar__initials" dominantBaseline="middle" textAnchor="middle" x="50%" y="54%">{ userInitials }</text>
+      <text className="ax-candytar__initials" textAnchor="middle" x="50%" y="65%">{ userInitials }</text>
     );
     /* eslint-enable max-len */
 


### PR DESCRIPTION
The PR is to implement a well supported way to align the Initials in the Candytar component.

I have tested on the latest versions of Chrome, Firefox and Safari only, so more QA may be needed.

![Screen Shot 2019-12-02 at 11 16 14](https://user-images.githubusercontent.com/7721684/69955400-77f04700-14f5-11ea-85e8-f78e8d7fa0ed.png)
![Screen Shot 2019-12-02 at 11 16 35](https://user-images.githubusercontent.com/7721684/69955401-7888dd80-14f5-11ea-8c89-5bbc56a5eff5.png)

