### PR TITLE
fix(checkbox): Browser jump when scrolled. 

### DIFF
--- a/packages/axiom-components/src/Form/ChedioButtox.css
+++ b/packages/axiom-components/src/Form/ChedioButtox.css
@@ -27,7 +27,7 @@
 
 .ax-checkbox__input,
 .ax-radio__input {
-  position: absolute;
+  position: fixed;
   opacity: 0;
   z-index: -1;
 }

--- a/site/components/Documentation/Resources/Components/Form.js
+++ b/site/components/Documentation/Resources/Components/Form.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 import {
   CheckBox,
   CheckBoxGroup,
@@ -23,6 +23,11 @@ import {
 const getTextInputIconTooltip = () => (
   <TooltipContext color="carbon"><TooltipContent>Some tooltip</TooltipContent></TooltipContext>
 );
+
+function ToggableCheckBox() {
+  const [checked, setChecked] = useState(false);
+  return <CheckBox checked={ checked } name="lorem" onChange={ () => setChecked(c => !c) } title="Lorem ipsum dolor sit amet">Lorem ipsum</CheckBox>;
+}
 
 export default class Documentation extends Component {
   render() {
@@ -122,9 +127,9 @@ export default class Documentation extends Component {
           <GridCell>
             <DocumentationShowCase>
               <CheckBoxGroup>
-                <CheckBox name="lorem" title="Lorem ipsum dolor sit amet">Lorem ipsum</CheckBox>
-                <CheckBox name="lorem" title="Lorem ipsum dolor sit amet">Lorem ipsum</CheckBox>
-                <CheckBox name="lorem" title="Lorem ipsum dolor sit amet">Lorem ipsum</CheckBox>
+                <ToggableCheckBox name="lorem" title="Lorem ipsum dolor sit amet">Lorem ipsum</ToggableCheckBox>
+                <ToggableCheckBox name="lorem" title="Lorem ipsum dolor sit amet">Lorem ipsum</ToggableCheckBox>
+                <ToggableCheckBox name="lorem" title="Lorem ipsum dolor sit amet">Lorem ipsum</ToggableCheckBox>
               </CheckBoxGroup>
             </DocumentationShowCase>
           </GridCell>


### PR DESCRIPTION
Setting the position to absolute caused a bug when the window was scrolled.
The browser would jump the scroll position to compensate for the difference between the absolutely positioned native element at the top of the page and the Axiom custom checkbox.

Example of bug [here](https://zfrfg.csb.app/)

![gif](https://user-images.githubusercontent.com/3940567/72556274-30036480-3896-11ea-9ab2-1e7e051f0af2.gif)

