### PR TITLE
fix: updates luxon to fix chrome 80 bug

### DIFF
--- a/packages/axiom-components/package.json
+++ b/packages/axiom-components/package.json
@@ -15,7 +15,7 @@
     "classnames": "^2.2.6",
     "element-closest": "^2.0.2",
     "lodash.omit": "^4.5.0",
-    "luxon": "^1.12.0",
+    "luxon": "^1.22.0",
     "popper.js": "1.12.5",
     "prop-types": "^15.6.0",
     "react": "^16.8.6",

--- a/packages/axiom-formatting/package.json
+++ b/packages/axiom-formatting/package.json
@@ -8,6 +8,6 @@
     "access": "public"
   },
   "dependencies": {
-    "luxon": "^1.12.0"
+    "luxon": "^1.22.0"
   }
 }

--- a/packages/axiom-formatting/src/formatDate.js
+++ b/packages/axiom-formatting/src/formatDate.js
@@ -8,4 +8,4 @@ export const FORMAT_MAP = {
   timezone: '(\'UTC\'ZZ)',
 };
 
-export default (formatStr) => date => DateTime.fromJSDate(date).toFormat(formatStr);
+export default (formatStr) => (date, timezone) => DateTime.fromJSDate(date, timezone ? { zone: timezone } : undefined).toFormat(formatStr);

--- a/packages/axiom-formatting/src/formatDate.test.js
+++ b/packages/axiom-formatting/src/formatDate.test.js
@@ -28,7 +28,7 @@ describe('formatDate', () => {
 
   describe('longDateWithTimezone', () => {
     it('formats dates correctly', () => {
-      expect(longDateWithTimezone(new Date(0))).toBe('Thu, 01 Jan 1970 00:00 (UTC+00:00)');
+      expect(longDateWithTimezone(new Date(0), 'Etc/UTC')).toBe('Thu, 01 Jan 1970 00:00 (UTC+00:00)');
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7425,10 +7425,10 @@ lru-cache@^4.1.2, lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-luxon@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.12.0.tgz#d02d53c8d8aaebe6b4c00ba1ce1be3913546b2e7"
-  integrity sha512-enPnPIHd5ZnZT0vpj9Xv8aq4j0yueAkhnh4xUKUHpqlgSm1r/8s6xTMjfyp2ugOWP7zivqJqgVTkW+rpHed61w==
+luxon@^1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.22.0.tgz#639525c7c69e594953c7b142794466b8ea85b868"
+  integrity sha512-3sLvlfbFo+AxVEY3IqxymbumtnlgBwjDExxK60W3d+trrUzErNAz/PfvPT+mva+vEUrdIodeCOs7fB6zHtRSrw==
 
 macaddress@^0.2.8:
   version "0.2.9"


### PR DESCRIPTION
In Chrome 80, there was a bug (either in Chrome or Luxon) that caused constructed dates to move forwards by 24 hours which was causing big issues for Vizia. We've updated on our side of things but here's a safety fix.

https://github.com/moment/luxon/issues/619