### PR TITLE
Move parts of globals.css into component specific CSS

### DIFF
--- a/packages/axiom-components/src/Base/globals.css
+++ b/packages/axiom-components/src/Base/globals.css
@@ -30,12 +30,3 @@ body[class*="ax-theme"],
   text-rendering: optimizeLegibility;
   line-height: var(--line-height-body);
 }
-
-textarea {
-  margin: 0; /* Remove the margin in Firefox and Safari. */
-  font: inherit;
-}
-
-textarea {
-  overflow: auto; /* Remove the default vertical scrollbar in IE. */
-}

--- a/packages/axiom-components/src/Base/globals.css
+++ b/packages/axiom-components/src/Base/globals.css
@@ -1,24 +1,26 @@
 /* stylelint-disable property-no-vendor-prefix, selector-max-type */
 /* stylelint-disable selector-max-universal */
-*,
-*::before,
-*::after {
+[class*="ax-theme"]*,
+[class*="ax-theme"]*::before,
+[class*="ax-theme"]*::after {
   box-sizing: inherit;
 }
 /* stylelint-enable selector-max-universal */
 
-html,
-body {
+html[class*="ax-theme"],
+body[class*="ax-theme"],
+[class*="ax-theme"] body {
   box-sizing: border-box;
 }
 
-html {
+html[class*="ax-theme"] {
   font-size: 100%;
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
 }
 
-body {
+body[class*="ax-theme"],
+[class*="ax-theme"] body {
   margin: 0;
   font-family: var(--font-family-body);
   font-size: var(--font-size-body);

--- a/packages/axiom-components/src/Base/globals.css
+++ b/packages/axiom-components/src/Base/globals.css
@@ -31,7 +31,6 @@ body[class*="ax-theme"],
   line-height: var(--line-height-body);
 }
 
-button,
 input {
   overflow: visible; /*  Show the overflow in Edge. */
 }
@@ -44,17 +43,4 @@ textarea {
 
 textarea {
   overflow: auto; /* Remove the default vertical scrollbar in IE. */
-}
-
-/* normalise button styles */
-button {
-  margin: 0;
-  border-radius: 0;
-  font: inherit;
-
-  /* Remove the inner border and padding in Firefox. */
-  &::-moz-focus-inner {
-    padding: 0;
-    border-style: none;
-  }
 }

--- a/packages/axiom-components/src/Base/globals.css
+++ b/packages/axiom-components/src/Base/globals.css
@@ -31,11 +31,6 @@ body[class*="ax-theme"],
   line-height: var(--line-height-body);
 }
 
-input {
-  overflow: visible; /*  Show the overflow in Edge. */
-}
-
-input,
 textarea {
   margin: 0; /* Remove the margin in Firefox and Safari. */
   font: inherit;

--- a/packages/axiom-components/src/Base/globals.css
+++ b/packages/axiom-components/src/Base/globals.css
@@ -1,8 +1,8 @@
 /* stylelint-disable property-no-vendor-prefix, selector-max-type */
 /* stylelint-disable selector-max-universal */
-[class*="ax-theme"]*,
-[class*="ax-theme"]*::before,
-[class*="ax-theme"]*::after {
+[class*="ax-theme"] *,
+[class*="ax-theme"] *::before,
+[class*="ax-theme"] *::after {
   box-sizing: inherit;
 }
 /* stylelint-enable selector-max-universal */

--- a/packages/axiom-components/src/Base/globals.css
+++ b/packages/axiom-components/src/Base/globals.css
@@ -32,7 +32,6 @@ body[class*="ax-theme"],
 }
 
 button,
-hr,
 input {
   overflow: visible; /*  Show the overflow in Edge. */
 }

--- a/packages/axiom-components/src/Button/Button.css
+++ b/packages/axiom-components/src/Button/Button.css
@@ -1,4 +1,16 @@
 .ax-button {
+  /* reset */
+  overflow: visible;
+  margin: 0;
+  border-radius: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/packages/axiom-components/src/Button/Button.css
+++ b/packages/axiom-components/src/Button/Button.css
@@ -1,7 +1,6 @@
 .ax-button {
   /* reset */
   overflow: visible;
-  margin: 0;
   border-radius: 0;
   font: inherit;
 

--- a/packages/axiom-components/src/Context/Context.css
+++ b/packages/axiom-components/src/Context/Context.css
@@ -146,6 +146,18 @@
 }
 
 .ax-context-menu__item {
+  /* reset */
+  overflow: visible;
+  margin: 0;
+  border-radius: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+
   display: flex;
   align-items: center;
   width: 100%;

--- a/packages/axiom-components/src/DatePicker/DatePicker.css
+++ b/packages/axiom-components/src/DatePicker/DatePicker.css
@@ -1,4 +1,16 @@
 .ax-date-picker__day {
+  /* reset */
+  overflow: visible;
+  margin: 0;
+  border-radius: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+
   display: block;
   position: relative;
   padding: 0 var(--spacing-grid-size);

--- a/packages/axiom-components/src/DatePicker/DatePickerRangeSelection.css
+++ b/packages/axiom-components/src/DatePicker/DatePickerRangeSelection.css
@@ -5,6 +5,18 @@
 }
 
 .ax-date-range-selection__item {
+  /* reset */
+  overflow: visible;
+  margin: 0;
+  border-radius: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+
   position: relative;
   height: var(--component-round-size-small);
   padding: 0 var(--spacing-grid-size--x2);

--- a/packages/axiom-components/src/Form/ChedioButtox.css
+++ b/packages/axiom-components/src/Form/ChedioButtox.css
@@ -12,6 +12,12 @@
   --cmp-checkbox-indeterminate-horizontal: calc(var(--cmp-input-checkbox-size) * 0.2);
 }
 
+.ax-chediobutton {
+  /* reset */
+  overflow: visible; /*  Show the overflow in Edge. */
+  font: inherit;
+}
+
 .ax-checkbox,
 .ax-radio {
   display: flex;

--- a/packages/axiom-components/src/Form/ChedioButtox.js
+++ b/packages/axiom-components/src/Form/ChedioButtox.js
@@ -51,7 +51,7 @@ export default class ChedioButtox extends Component {
           space="x2"
           title={ title }>
         <input { ...rest }
-            className={ `${className}__input` }
+            className={ `${className}__input ax-chediobuttox` }
             disabled={ disabled }
             type={ inputType } />
 

--- a/packages/axiom-components/src/Form/TextArea.css
+++ b/packages/axiom-components/src/Form/TextArea.css
@@ -1,4 +1,9 @@
 .ax-textarea {
+  /* reset */
+  margin: 0; /* Remove the margin in Firefox and Safari. */
+  font: inherit;
+  overflow: auto; /* Remove the default vertical scrollbar in IE. */
+
   padding: var(--component-padding-vertical-medium) var(--component-padding-horizontal-small);
   border: 0;
   border-radius: var(--component-border-radius);

--- a/packages/axiom-components/src/Form/TextInput.css
+++ b/packages/axiom-components/src/Form/TextInput.css
@@ -1,4 +1,8 @@
 .ax-input {
+  /* reset */
+  overflow: visible; /*  Show the overflow in Edge. */
+  font: inherit;
+
   flex: 1 1 auto;
   border: 0;
   background-color: transparent;

--- a/packages/axiom-components/src/Menu/Menu.css
+++ b/packages/axiom-components/src/Menu/Menu.css
@@ -17,6 +17,18 @@
 }
 
 .ax-menu__item-button {
+  /* reset */
+  overflow: visible;
+  margin: 0;
+  border-radius: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+
   display: flex;
   flex: 0 1 auto;
   align-items: center;

--- a/packages/axiom-components/src/Separator/Separator.css
+++ b/packages/axiom-components/src/Separator/Separator.css
@@ -1,6 +1,7 @@
 .ax-separator {
   width: 100%;
   border-color: var(--color-theme-border);
+  overflow: visible;
 }
 
 .ax-separator--solid {

--- a/packages/axiom-components/src/Table/Table.css
+++ b/packages/axiom-components/src/Table/Table.css
@@ -71,6 +71,18 @@
 }
 
 .ax-table__header-button {
+  /* reset */
+  overflow: visible;
+  margin: 0;
+  border-radius: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+
   display: inline-flex;
   position: relative;
   align-items: center;

--- a/packages/axiom-components/src/Tabset/Tabset.css
+++ b/packages/axiom-components/src/Tabset/Tabset.css
@@ -48,6 +48,18 @@
 }
 
 .ax-tabset__button {
+  /* reset */
+  overflow: visible;
+  margin: 0;
+  border-radius: 0;
+  font: inherit;
+
+  /* Remove the inner border and padding in Firefox. */
+  &::-moz-focus-inner {
+    padding: 0;
+    border-style: none;
+  }
+
   outline: 0;
   border: 0;
   background: none;

--- a/packages/axiom-components/src/Toggle/Toggle.css
+++ b/packages/axiom-components/src/Toggle/Toggle.css
@@ -27,6 +27,10 @@
 }
 
 .ax-toggle__input {
+  /* reset */
+  overflow: visible; /*  Show the overflow in Edge. */
+  font: inherit;
+
   position: absolute;
   opacity: 0;
   cursor: inherit;


### PR DESCRIPTION
I came across an issue where the CSS from the `globals.css` of Axiom would _leak_ into the rest of the app (if that app isn't fully axiom-based).
As the `ax-theme--[day|night]` CSS class is _required_  anyways to get Axiom to apply styles correctly I figured we could just scope the `globals.css` by that. This works for `html`, `body` and `*` selectors but unfortunately it increases the [CSS Specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) of the selectors and results in the styles for elements like `button`, `input` and `textarea` to not be applied (technically they are applied, they are just _overwritten_).

I ended up removing some CSS from the `globals.css` and add it to their respective components. This is obviously duplicating some CSS but I think this is way more explicity anyways.