### PR TITLE
Remove unsafe componentWillMount

### DIFF
--- a/packages/axiom-components/src/Dropdown/DropdownContext.js
+++ b/packages/axiom-components/src/Dropdown/DropdownContext.js
@@ -45,10 +45,6 @@ export default class DropdownContext extends Component {
     this.handleMouseMove = this.handleMouseMove.bind(this);
   }
 
-  UNSAFE_componentWillMount() {
-    document.addEventListener("keydown", this.handleKeyDown);
-  }
-
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown);
     document.removeEventListener("mousedown", this.handleClick);
@@ -56,6 +52,7 @@ export default class DropdownContext extends Component {
   }
 
   componentDidMount() {
+    document.addEventListener("keydown", this.handleKeyDown);
     document.addEventListener("mousedown", this.handleClick);
     document.addEventListener("mousemove", this.handleMouseMove);
   }

--- a/packages/axiom-components/src/Portal/Portal.js
+++ b/packages/axiom-components/src/Portal/Portal.js
@@ -14,7 +14,8 @@ export default class Portal extends Component {
     axiomPositionParentNode: PropTypes.object,
   };
 
-  UNSAFE_componentWillMount() {
+  constructor(props) {
+    super(props);
     if (!canOpenPortal) return;
     this._reactRootNode = document.createElement("div");
     this._reactRootNode.classList.add("AxiomSubtree");

--- a/packages/axiom-components/src/Progress/Progress.stories.js
+++ b/packages/axiom-components/src/Progress/Progress.stories.js
@@ -1,5 +1,7 @@
-import React from "react";
-import Progress from "./Progress";
+import React from 'react';
+import Progress from './Progress';
+import ProgressFinite from './ProgressFinite';
+import ProgressInfinite from './ProgressInfinite';
 
 const SvgFilters = () => (
   <svg height="0" width="0" xmlns="http://www.w3.org/2000/svg">
@@ -37,6 +39,7 @@ const SvgFilters = () => (
 export default {
   title: "Components/Progress",
   component: Progress,
+  subcomponents: { ProgressFinite, ProgressInfinite },
   decorators: [
     // eslint-disable-next-line react/display-name
     (storyFn) => (
@@ -49,5 +52,11 @@ export default {
 };
 
 export function Default() {
-  return <Progress />;
+  return (
+    <React.Fragment>
+      <Progress complete />
+      <ProgressFinite percent={50} />
+      <ProgressInfinite />
+    </React.Fragment>
+  );
 }

--- a/packages/axiom-components/src/Progress/Progress.stories.js
+++ b/packages/axiom-components/src/Progress/Progress.stories.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import Progress from './Progress';
-import ProgressFinite from './ProgressFinite';
-import ProgressInfinite from './ProgressInfinite';
+import React from "react";
+import Progress from "./Progress";
+import ProgressFinite from "./ProgressFinite";
+import ProgressInfinite from "./ProgressInfinite";
 
 const SvgFilters = () => (
   <svg height="0" width="0" xmlns="http://www.w3.org/2000/svg">

--- a/packages/axiom-components/src/Progress/ProgressFinite.js
+++ b/packages/axiom-components/src/Progress/ProgressFinite.js
@@ -20,7 +20,11 @@ export default class ProgressFinite extends Component {
     size: "small",
   };
 
-  UNSAFE_componentWillMount = renderFilter;
+  constructor(props) {
+    super(props);
+  }
+
+  componentDidMount = renderFilter;
 
   render() {
     const { percent, ...rest } = this.props;

--- a/packages/axiom-components/src/Progress/ProgressInfinite.js
+++ b/packages/axiom-components/src/Progress/ProgressInfinite.js
@@ -21,7 +21,7 @@ export default class ProgressInfinite extends Component {
     size: "small",
   };
 
-  UNSAFE_componentWillMount = renderFilter;
+  componentDidMount = renderFilter;
 
   render() {
     const { color, ...rest } = this.props;

--- a/packages/axiom-components/src/Validation/Validate.js
+++ b/packages/axiom-components/src/Validation/Validate.js
@@ -49,7 +49,7 @@ export default class Validate extends Component {
     this.id = uuid();
   }
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     if (!this.shouldValidate()) return;
 
     this.context.registerValidate(this.validationGetter, this.id);

--- a/packages/axiom-documentation-viewer/src/DocumentationApi.js
+++ b/packages/axiom-documentation-viewer/src/DocumentationApi.js
@@ -22,7 +22,7 @@ export default class DocumentationApi extends Component {
     registerPropTypes: PropTypes.func.isRequired,
   };
 
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     this.context.registerPropTypes(this.props.components);
   }
 


### PR DESCRIPTION
`componentWillMount` is now marked as legacy and will be dropped completely in React 17. 

There is no direct replacement. `componentWillMount` methods will be moved to either the constructor or `componentDidMount` depending if they need to happen before or after first `render`.

![Screenshot 2020-04-02 at 14 11 49](https://user-images.githubusercontent.com/3940567/78253184-ecf77b80-74eb-11ea-9da8-f2ca352bbc7e.png)
