### PR TITLE
AX-203: Rename Button attribute style => variant 

### DIFF
--- a/packages/axiom-components/src/Button/Button.js
+++ b/packages/axiom-components/src/Button/Button.js
@@ -31,8 +31,13 @@ export default class Button extends Component {
     shape: PropTypes.oneOf(["circle", "rectangle", "stadium"]),
     /** Size of standard shape */
     size: PropTypes.oneOf(["small", "medium", "large", "huge"]),
-    /** Style of the Button, which affects its coloring and sizing */
-    style: PropTypes.oneOf(["primary", "secondary", "tertiary", "quaternary"]),
+    /** variant of the Button, which affects its coloring and sizing */
+    variant: PropTypes.oneOf([
+      "primary",
+      "secondary",
+      "tertiary",
+      "quaternary",
+    ]),
   };
 
   static contextTypes = {
@@ -43,7 +48,7 @@ export default class Button extends Component {
     color: "accent",
     shape: "rectangle",
     size: "medium",
-    style: "primary",
+    variant: "primary",
   };
 
   render() {
@@ -57,7 +62,7 @@ export default class Button extends Component {
       joinedLeft,
       joinedRight,
       shape,
-      style,
+      variant,
       size,
       full,
       ...rest
@@ -70,7 +75,7 @@ export default class Button extends Component {
     const classes = classnames(
       "ax-button",
       `ax-button--${color}`,
-      `ax-button--${style}`,
+      `ax-button--${variant}`,
       `ax-button--${shape}-${size}`,
       {
         "ax-button--active": active,

--- a/packages/axiom-components/src/Button/Button.stories.js
+++ b/packages/axiom-components/src/Button/Button.stories.js
@@ -13,16 +13,16 @@ export default {
 export function Style() {
   return (
     <ButtonGroup space="x2">
-      <Button size="small" style="primary">
+      <Button size="small" variant="primary">
         Primary
       </Button>
-      <Button size="small" style="secondary">
+      <Button size="small" variant="secondary">
         Secondary
       </Button>
-      <Button size="small" style="tertiary">
+      <Button size="small" variant="tertiary">
         Tertiary
       </Button>
-      <Button size="small" style="quaternary">
+      <Button size="small" variant="quaternary">
         Quaternary
       </Button>
     </ButtonGroup>
@@ -64,13 +64,13 @@ export function Shape() {
 export function Icon() {
   return (
     <ButtonGroup>
-      <Button shape="circle" style="secondary">
+      <Button shape="circle" variant="secondary">
         <ButtonIcon name="twitter" />
       </Button>
-      <Button shape="circle" style="quaternary">
+      <Button shape="circle" variant="quaternary">
         <ButtonIcon name="cross" />
       </Button>
-      <Button style="primary">
+      <Button variant="primary">
         Search
         <ButtonIcon name="magnify-glass" />
       </Button>
@@ -98,10 +98,10 @@ export function Progress() {
 export function Joined() {
   return (
     <ButtonGroup joined>
-      <Button size="small" style="primary">
+      <Button size="small" variant="primary">
         Submit
       </Button>
-      <Button size="small" style="secondary">
+      <Button size="small" variant="secondary">
         Cancel
       </Button>
     </ButtonGroup>

--- a/packages/axiom-components/src/Button/Button.test.js
+++ b/packages/axiom-components/src/Button/Button.test.js
@@ -39,10 +39,10 @@ describe("Button", () => {
     });
   });
 
-  describe("renders with style", () => {
-    ["primary", "secondary", "tertiary", "quaternary"].forEach((style) => {
-      it(style, () => {
-        const component = getComponent({ style });
+  describe("renders with variant", () => {
+    ["primary", "secondary", "tertiary", "quaternary"].forEach((variant) => {
+      it(variant, () => {
+        const component = getComponent({ variant });
         const tree = component.toJSON();
         expect(tree).toMatchSnapshot();
       });

--- a/packages/axiom-components/src/Button/__snapshots__/Button.test.js.snap
+++ b/packages/axiom-components/src/Button/__snapshots__/Button.test.js.snap
@@ -168,7 +168,7 @@ exports[`Button renders with shape with size stadium with small 1`] = `
 </button>
 `;
 
-exports[`Button renders with style primary 1`] = `
+exports[`Button renders with variant primary 1`] = `
 <button
   className="ax-button ax-button--accent ax-button--primary ax-button--rectangle-medium"
 >
@@ -176,7 +176,7 @@ exports[`Button renders with style primary 1`] = `
 </button>
 `;
 
-exports[`Button renders with style quaternary 1`] = `
+exports[`Button renders with variant quaternary 1`] = `
 <button
   className="ax-button ax-button--accent ax-button--quaternary ax-button--rectangle-medium"
 >
@@ -184,7 +184,7 @@ exports[`Button renders with style quaternary 1`] = `
 </button>
 `;
 
-exports[`Button renders with style secondary 1`] = `
+exports[`Button renders with variant secondary 1`] = `
 <button
   className="ax-button ax-button--accent ax-button--secondary ax-button--rectangle-medium"
 >
@@ -192,7 +192,7 @@ exports[`Button renders with style secondary 1`] = `
 </button>
 `;
 
-exports[`Button renders with style tertiary 1`] = `
+exports[`Button renders with variant tertiary 1`] = `
 <button
   className="ax-button ax-button--accent ax-button--tertiary ax-button--rectangle-medium"
 >

--- a/packages/axiom-components/src/DatePicker/DatePickerControls.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerControls.js
@@ -59,10 +59,14 @@ export default class DatePickerControls extends Component {
 
         <GridCell shrink>
           <ButtonGroup>
-            <Button onClick={this.handleApply} size="small" style="primary">
+            <Button onClick={this.handleApply} size="small" variant="primary">
               Apply
             </Button>
-            <Button onClick={this.handleCancel} size="small" style="secondary">
+            <Button
+              onClick={this.handleCancel}
+              size="small"
+              variant="secondary"
+            >
               Cancel
             </Button>
           </ButtonGroup>

--- a/packages/axiom-components/src/DatePicker/DatePickerHeaderControl.js
+++ b/packages/axiom-components/src/DatePicker/DatePickerHeaderControl.js
@@ -43,7 +43,7 @@ export default class DatePickerHeaderControl extends Component {
           <Button
             disabled={isSameOrBeforeMonth(date, earliestSelectableDate)}
             onClick={() => onPrevious()}
-            style="quaternary"
+            variant="quaternary"
           >
             <ButtonIcon name="chevron-left" />
           </Button>
@@ -59,7 +59,7 @@ export default class DatePickerHeaderControl extends Component {
           <Button
             disabled={isSameOrAfterMonth(date, latestSelectableDate)}
             onClick={() => onNext()}
-            style="quaternary"
+            variant="quaternary"
           >
             <ButtonIcon name="chevron-right" />
           </Button>

--- a/packages/axiom-components/src/Dialog/Dialog.stories.js
+++ b/packages/axiom-components/src/Dialog/Dialog.stories.js
@@ -36,7 +36,7 @@ export function Default() {
         </DialogBody>
         <DialogFooter>
           <ButtonGroup textRight>
-            <Button onClick={closeDialog} style="secondary">
+            <Button onClick={closeDialog} variant="secondary">
               Cancel
             </Button>
             <Button onClick={closeDialog}>Continue</Button>

--- a/packages/axiom-components/src/Dropdown/Dropdown.stories.js
+++ b/packages/axiom-components/src/Dropdown/Dropdown.stories.js
@@ -297,13 +297,13 @@ export function ClosingTheDropdown() {
       </div>
       <Dropdown ref={dropdownRef}>
         <DropdownTarget>
-          <Button size="small" style="secondary">
+          <Button size="small" variant="secondary">
             Open
           </Button>
         </DropdownTarget>
         <DropdownSource>
           <DropdownContext width="100%">
-            <Button onClick={closeDropdown} size="small" style="secondary">
+            <Button onClick={closeDropdown} size="small" variant="secondary">
               Close
             </Button>
           </DropdownContext>

--- a/packages/axiom-components/src/Icon/IconButton.js
+++ b/packages/axiom-components/src/Icon/IconButton.js
@@ -78,7 +78,7 @@ export default class IconButton extends Component {
     const { name, size, buttonStyle, iconColor, ...rest } = this.props;
 
     return (
-      <Button {...rest} shape="circle" size={size} style={buttonStyle}>
+      <Button {...rest} shape="circle" size={size} variant={buttonStyle}>
         <ButtonIcon color={iconColor} name={name} size={sizeMap[size]} />
       </Button>
     );

--- a/packages/axiom-components/src/Pagination/PaginationButton.js
+++ b/packages/axiom-components/src/Pagination/PaginationButton.js
@@ -19,7 +19,7 @@ export default class PaginationButton extends Component {
         onClick={() => onClick(page)}
         shape={shape || page <= 99 ? "circle" : "stadium"}
         size="small"
-        style={active ? "primary" : "quaternary"}
+        variant={active ? "primary" : "quaternary"}
       />
     );
   }

--- a/packages/axiom-components/src/Progress/ProgressButton.js
+++ b/packages/axiom-components/src/Progress/ProgressButton.js
@@ -35,7 +35,7 @@ export default class ProgressButton extends Component {
     });
 
     return (
-      <Button {...rest} active={isInProgress} size={size} style="primary">
+      <Button {...rest} active={isInProgress} size={size} variant="primary">
         <div className={classes}>
           <Cloak
             className="ax-progress-button__content"

--- a/packages/axiom-components/src/Tooltip/Tooltip.stories.js
+++ b/packages/axiom-components/src/Tooltip/Tooltip.stories.js
@@ -82,7 +82,7 @@ export function WithRef() {
         onClick={() => {
           ref.current.hideTooltip();
         }}
-        style="secondary"
+        variant="secondary"
       >
         Close
       </Button>

--- a/packages/axiom-components/src/Transition/Transition.stories.js
+++ b/packages/axiom-components/src/Transition/Transition.stories.js
@@ -23,7 +23,7 @@ function WrapperComponet({ storyFn }) {
           onClick={() => setActiveIndex((i) => i - 1)}
           shape="circle"
           size="small"
-          style="secondary"
+          variant="secondary"
         >
           <Icon name="chevron-left" />
         </Button>
@@ -33,7 +33,7 @@ function WrapperComponet({ storyFn }) {
           onClick={() => setActiveIndex((i) => i + 1)}
           shape="circle"
           size="small"
-          style="secondary"
+          variant="secondary"
         >
           <Icon name="chevron-right" />
         </Button>

--- a/packages/axiom-composites/src/ChangePasswordDialog/ChangePasswordDialog.js
+++ b/packages/axiom-composites/src/ChangePasswordDialog/ChangePasswordDialog.js
@@ -154,7 +154,7 @@ export default class ChangePasswordDialog extends Component {
               <Button
                 data-ax-at={atIds.ChangePassword.cancel}
                 onClick={onRequestClose}
-                style="secondary"
+                variant="secondary"
                 type="button"
               >
                 {t("Cancel", axiomLanguage)}


### PR DESCRIPTION
Style is a key word in JSX often used to apply inline styles. It's use causes confusion and linter warnings. Here we replace with variant. Codemod [here](https://www.npmjs.com/package/axiom-codemods).

BREAKING CHANGE: 🧨
`<Button style="primary">` becomes `<Button variant="primary">`
Please use `npx axiom-codemods rename-button-style-attribute <path>` to replace in your code.