### PR TITLE
ci: 🎡 Deploy to Netlify action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,15 @@ jobs:
     - run: yarn install --verbose --frozen-lockfile
     - run: yarn build:esm:packages
     - run: yarn build:storybook
+    - name: Deploy to Netlify
+      uses: nwtgck/actions-netlify@v1.1
+      with:
+        publish-dir: './storybook-static'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        deploy-message: "Deploy from GitHub Actions"
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
   build-cjs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Restores PR preview builds. 

We push the built Storybook files to Netlify to avoid the need to build twice as we previously did. Also by building on gh actions we don't use the limited netlify build minutes.

Uses [actions-netlify](https://github.com/nwtgck/actions-netlify)