### PR TITLE
docs: theme storybook with Axiom colors

### DIFF
--- a/.storybook/axiomTheme.js
+++ b/.storybook/axiomTheme.js
@@ -1,6 +1,44 @@
-import { create } from '@storybook/theming/create';
+import { create } from "@storybook/theming/create";
+import logo from "./static_assets/axiom-text.svg";
+
+const borderColor = "rgba(63,63,63, 0.2)"; // --color-theme-day-border: rgba(var(--rgb-theme-day-main), var(--opacity-border));
+const active = "#239EDB"; // --color-ui-accent--active;
+const white = "#FFFFFF"; // --rgb-ui-white:
+const whiteNoiseDefault = "#F8F8F8"; // --rgb-ui-white-noise
+const carbonDefault = "#3F3F3F"; // --rgb-ui-carbon
+const componentBorderRadius = "0.1875rem"; // --component-border-radius;
 
 export default create({
-  brandTitle: 'Axiom',
-  brandUrl: 'https://axiom.brandwatch.com/',
+  base: "light", // base to extend I guess this is SB's light theme
+
+  brandTitle: "Axiom",
+  brandUrl: "https://github.com/BrandwatchLtd/axiom-react",
+  brandImage: logo,
+  //colorPrimary: "palegoldenrod", // Not sure where this is used
+  colorSecondary: active, // active used in side bar for active story
+
+  //UI
+  appBg: whiteNoiseDefault,
+  appContentBg: white,
+  appBorderColor: borderColor,
+  appBorderRadius: componentBorderRadius,
+
+  // Typography
+  fontBase: "Roboto",
+  fontCode: "Monaco", // font used for code samples
+
+  // Text colors
+  textColor: carbonDefault,
+  //textInverseColor: "pink", // Used in Action Logger and notifications
+
+  // Toolbar default and active colors
+  barTextColor: carbonDefault,
+  barSelectedColor: active, //active
+  barBg: white,
+
+  // Form colors
+  inputBg: white,
+  inputBorder: borderColor,
+  inputTextColor: carbonDefault,
+  inputBorderRadius: componentBorderRadius,
 });

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,17 @@
+<style type="text/css">
+  .sidebar-item {
+    line-height: 1.25rem !important; /* --line-height-body */
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+
+  /* hides storybook folder icons */
+  svg.sidebar-svg-icon,
+  .sidebar-expander {
+    display: none !important;
+  }
+
+  #introduction--page {
+    border-bottom: rgba(63, 63, 63, 0.2) solid 0.0625rem;
+  }
+</style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700" rel="stylesheet">

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,12 @@
 import { addParameters } from "@storybook/react";
+import axiomTheme from "./axiomTheme";
 
 addParameters({
   options: {
+    theme: axiomTheme,
     storySort: {
       method: "alphabetical",
-      order: ["Intro", "Components"],
+      order: ["Introduction"],
     },
   },
 });

--- a/.storybook/static_assets/axiom-text.svg
+++ b/.storybook/static_assets/axiom-text.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="940px" height="266px" viewBox="0 0 940 266" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="100px" height="40px" viewBox="0 0 940 266" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
     <title>axiom-text</title>
     <desc>Created with Sketch.</desc>

--- a/packages/axiom-components/src/AlertBar/AlertBar.stories.js
+++ b/packages/axiom-components/src/AlertBar/AlertBar.stories.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import AlertBar from "./AlertBar";
 
 export default {
-  title: "Components/AlertBar",
+  title: "AlertBar",
   component: AlertBar,
 };
 

--- a/packages/axiom-components/src/AlertCard/AlertCard.stories.js
+++ b/packages/axiom-components/src/AlertCard/AlertCard.stories.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import AlertCard from "./AlertCard";
 
 export default {
-  title: "Components/AlertCard",
+  title: "AlertCard",
   component: AlertCard,
 };
 

--- a/packages/axiom-components/src/AlertDialog/AlertDialog.stories.js
+++ b/packages/axiom-components/src/AlertDialog/AlertDialog.stories.js
@@ -5,7 +5,7 @@ import AlertDialogBody from "./AlertDialogBody";
 import Button from "../Button/Button";
 
 export default {
-  title: "Components/AlertDialog",
+  title: "AlertDialog",
   component: AlertDialog,
   subcomponents: { AlertDialogHeader, AlertDialogBody },
 };

--- a/packages/axiom-components/src/AlertIcon/AlertIcon.stories.js
+++ b/packages/axiom-components/src/AlertIcon/AlertIcon.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import AlertIcon from "./AlertIcon";
 
 export default {
-  title: "Components/AlertIcon",
+  title: "AlertIcon",
   component: AlertIcon,
 };
 

--- a/packages/axiom-components/src/Animation/Animation.stories.js
+++ b/packages/axiom-components/src/Animation/Animation.stories.js
@@ -5,7 +5,7 @@ import Grid from "../Grid/Grid";
 import GridCell from "../Grid/GridCell";
 
 export default {
-  title: "Components/Animation",
+  title: "Animation",
   component: Animation,
 };
 

--- a/packages/axiom-components/src/Avatar/Avatar.stories.js
+++ b/packages/axiom-components/src/Avatar/Avatar.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import Avatar from "./Avatar";
 
 export default {
-  title: "Components/Avatar",
+  title: "Avatar",
   component: Avatar,
 };
 

--- a/packages/axiom-components/src/Avatar/Candytar.stories.js
+++ b/packages/axiom-components/src/Avatar/Candytar.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import Candytar from "./Candytar";
 
 export default {
-  title: "Components/Candytar",
+  title: "Candytar",
   component: Candytar,
 };
 

--- a/packages/axiom-components/src/Badge/Badge.stories.js
+++ b/packages/axiom-components/src/Badge/Badge.stories.js
@@ -3,7 +3,7 @@ import Badge from "./Badge";
 import BadgeGroup from "./BadgeGroup";
 
 export default {
-  title: "Components/Badge",
+  title: "Badge",
   component: Badge,
 };
 

--- a/packages/axiom-components/src/Base/Base.stories.js
+++ b/packages/axiom-components/src/Base/Base.stories.js
@@ -6,7 +6,7 @@ import Card from "../Card/Card";
 import CardContent from "../Card/CardContent";
 
 export default {
-  title: "Components/Base",
+  title: "Base",
   component: Base,
 };
 

--- a/packages/axiom-components/src/Button/Button.stories.js
+++ b/packages/axiom-components/src/Button/Button.stories.js
@@ -5,7 +5,7 @@ import ButtonIcon from "./ButtonIcon";
 import ProgressButton from "../Progress/ProgressButton";
 
 export default {
-  title: "Components/Button",
+  title: "Button",
   component: Button,
   subcomponents: { ButtonGroup, ButtonIcon, ProgressButton },
 };

--- a/packages/axiom-components/src/Card/Card.stories.js
+++ b/packages/axiom-components/src/Card/Card.stories.js
@@ -17,7 +17,7 @@ import Candytar from "../Avatar/Candytar";
 import Heading from "../Typography/Heading";
 
 export default {
-  title: "Components/Card",
+  title: "Card",
   component: Card,
   subcomponents: { CardContent, CardCaption, CardImage, CardList },
   decorators: [withKnobs],

--- a/packages/axiom-components/src/Chip/Chip.stories.js
+++ b/packages/axiom-components/src/Chip/Chip.stories.js
@@ -3,7 +3,7 @@ import Chip from "./Chip";
 import ChipList from "./ChipList";
 
 export default {
-  title: "Components/Chip",
+  title: "Chip",
   component: Chip,
   subcomponents: { ChipList },
 };

--- a/packages/axiom-components/src/Cloak/Cloak.stories.js
+++ b/packages/axiom-components/src/Cloak/Cloak.stories.js
@@ -8,7 +8,7 @@ import Heading from "../Typography/Heading";
 import Base from "../Base/Base";
 
 export default {
-  title: "Components/Cloak",
+  title: "Cloak",
   component: Cloak,
   subComponents: { CloakContainer },
 };

--- a/packages/axiom-components/src/ColorPicker/ColorPicker.stories.js
+++ b/packages/axiom-components/src/ColorPicker/ColorPicker.stories.js
@@ -4,7 +4,7 @@ import ColorPicker from "./ColorPicker";
 import { withKnobs, boolean } from "@storybook/addon-knobs";
 
 export default {
-  title: "Components/ColorPicker",
+  title: "ColorPicker",
   component: ColorPicker,
   decorators: [withKnobs],
 };

--- a/packages/axiom-components/src/DataPicker/DatePicker.stories.js
+++ b/packages/axiom-components/src/DataPicker/DatePicker.stories.js
@@ -10,7 +10,7 @@ import Icon from "../Icon/Icon";
 import Small from "../Typography/Small";
 
 export default {
-  title: "Components/DataPicker",
+  title: "DataPicker",
   component: DataPicker,
 };
 

--- a/packages/axiom-components/src/DatePicker/DatePicker.stories.js
+++ b/packages/axiom-components/src/DatePicker/DatePicker.stories.js
@@ -11,7 +11,7 @@ import Button from "../Button/Button";
 import ButtonIcon from "../Button/ButtonIcon";
 
 export default {
-  title: "Components/DatePicker",
+  title: "DatePicker",
   component: DatePicker,
   subcomponents: {
     DatePickerContext,

--- a/packages/axiom-components/src/Dialog/Dialog.stories.js
+++ b/packages/axiom-components/src/Dialog/Dialog.stories.js
@@ -8,7 +8,7 @@ import ButtonGroup from "../Button/ButtonGroup";
 import Heading from "../Typography/Heading";
 
 export default {
-  title: "Components/Dialog",
+  title: "Dialog",
   component: Dialog,
   subcomponents: { DialogHeader, DialogBody, DialogFooter },
 };

--- a/packages/axiom-components/src/Dropdown/Dropdown.stories.js
+++ b/packages/axiom-components/src/Dropdown/Dropdown.stories.js
@@ -21,7 +21,7 @@ import Button from "../Button/Button";
 import "./Dropdown.stories.css";
 
 export default {
-  title: "Components/Dropdown",
+  title: "Dropdown",
   component: Dropdown,
   subcomponents: {
     DropdownTarget,

--- a/packages/axiom-components/src/Dropdown/Dropdown.stories.mdx
+++ b/packages/axiom-components/src/Dropdown/Dropdown.stories.mdx
@@ -3,7 +3,7 @@ import * as stories from "./Dropdown.stories.js";
 import Dropdown from "./Dropdown";
 import DropdownContext from "./DropdownContext";
 
-<Meta title="Components/Dropdown" component={Dropdown}/>
+<Meta title="Dropdown" component={Dropdown}/>
 
 <Title>Dropdown</Title>
 

--- a/packages/axiom-components/src/DurationPicker/DurationPicker.stories.js
+++ b/packages/axiom-components/src/DurationPicker/DurationPicker.stories.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import DurationPicker from "./DurationPicker";
 
 export default {
-  title: "Components/DurationPicker",
+  title: "DurationPicker",
   component: DurationPicker,
 };
 

--- a/packages/axiom-components/src/Editable/Editable.stories.js
+++ b/packages/axiom-components/src/Editable/Editable.stories.js
@@ -4,7 +4,7 @@ import EditableLine from "./EditableLine";
 import Heading from "../Typography/Heading";
 
 export default {
-  title: "Components/Editable",
+  title: "Editable",
   component: EditableLine,
 };
 

--- a/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.stories.js
+++ b/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import EllipsisTooltip from "./EllipsisTooltip";
 
 export default {
-  title: "Components/EllipsisTooltip",
+  title: "EllipsisTooltip",
   component: EllipsisTooltip,
 };
 

--- a/packages/axiom-components/src/Flag/Flag.stories.js
+++ b/packages/axiom-components/src/Flag/Flag.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import Flag from "./Flag";
 
 export default {
-  title: "Components/Flag",
+  title: "Flag",
   component: Flag,
 };
 

--- a/packages/axiom-components/src/Form/CheckBox.stories.js
+++ b/packages/axiom-components/src/Form/CheckBox.stories.js
@@ -4,7 +4,7 @@ import CheckBox from "./CheckBox";
 import CheckBoxGroup from "./CheckBoxGroup";
 
 export default {
-  title: "Components/Form/CheckBox",
+  title: "Form/CheckBox",
   component: CheckBox,
 };
 

--- a/packages/axiom-components/src/Form/Form.stories.js
+++ b/packages/axiom-components/src/Form/Form.stories.js
@@ -6,7 +6,7 @@ import AlertBar from "../AlertBar/AlertBar";
 import Paragraph from "../Typography/Paragraph";
 
 export default {
-  title: "Components/Form",
+  title: "Form",
   component: Form,
 };
 

--- a/packages/axiom-components/src/Form/RadioButton.stories.js
+++ b/packages/axiom-components/src/Form/RadioButton.stories.js
@@ -3,7 +3,7 @@ import RadioButton from "./RadioButton";
 import RadioButtonGroup from "./RadioButtonGroup";
 
 export default {
-  title: "Components/Form/RadioButton",
+  title: "Form/RadioButton",
   component: RadioButton,
 };
 

--- a/packages/axiom-components/src/Form/TextArea.stories.js
+++ b/packages/axiom-components/src/Form/TextArea.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import TextArea from "./TextArea";
 
 export default {
-  title: "Components/Form/TextArea",
+  title: "Form/TextArea",
   component: TextArea,
 };
 

--- a/packages/axiom-components/src/Form/TextInput.stories.js
+++ b/packages/axiom-components/src/Form/TextInput.stories.js
@@ -6,7 +6,7 @@ import TextInputButton from "./TextInputButton";
 import InlineValidation from "../Validation/InlineValidation";
 
 export default {
-  title: "Components/Form/TextInput",
+  title: "Form/TextInput",
   component: TextInput,
   subcomponents: { TextInputButton, TextInputIcon },
 };

--- a/packages/axiom-components/src/Grid/Grid.stories.js
+++ b/packages/axiom-components/src/Grid/Grid.stories.js
@@ -8,7 +8,7 @@ import TextInput from "../Form/TextInput";
 import "./Grid.stories.css";
 
 export default {
-  title: "Components/Grid",
+  title: "Grid",
   component: Grid,
   decorators: [withKnobs],
   subcomponents: { GridCell },

--- a/packages/axiom-components/src/Icon/Icon.stories.js
+++ b/packages/axiom-components/src/Icon/Icon.stories.js
@@ -5,7 +5,7 @@ import GridCell from "../Grid/GridCell";
 import iconNames from "./iconNames";
 
 export default {
-  title: "Components/Icon",
+  title: "Icon",
   component: Icon,
 };
 

--- a/packages/axiom-components/src/Icon/IconButton.stories.js
+++ b/packages/axiom-components/src/Icon/IconButton.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import IconButton from "./IconButton";
 
 export default {
-  title: "Components/IconButton",
+  title: "IconButton",
   component: IconButton,
 };
 

--- a/packages/axiom-components/src/Image/Image.stories.js
+++ b/packages/axiom-components/src/Image/Image.stories.js
@@ -3,7 +3,7 @@ import Image from "./Image";
 import AlertBar from "../AlertBar/AlertBar";
 
 export default {
-  title: "Components/Image",
+  title: "Image",
   component: Image,
 };
 

--- a/packages/axiom-components/src/Label/Label.stories.js
+++ b/packages/axiom-components/src/Label/Label.stories.js
@@ -4,7 +4,7 @@ import LabelGroup from "./LabelGroup";
 import LabelIcon from "./LabelIcon";
 
 export default {
-  title: "Components/Label",
+  title: "Label",
   component: Label,
   subcomponents: { LabelIcon, LabelGroup },
 };

--- a/packages/axiom-components/src/List/List.stories.js
+++ b/packages/axiom-components/src/List/List.stories.js
@@ -3,7 +3,7 @@ import List from "./List";
 import ListItem from "./ListItem";
 
 export default {
-  title: "Components/List",
+  title: "List",
   component: List,
   subcomponents: { ListItem },
 };

--- a/packages/axiom-components/src/Logo/Logo.stories.js
+++ b/packages/axiom-components/src/Logo/Logo.stories.js
@@ -5,7 +5,7 @@ import LogoTab from "./LogoTab";
 import LogoHorizontal from "./LogoHorizontal";
 
 export default {
-  title: "Components/Logo",
+  title: "Logo",
   component: Logo,
 };
 

--- a/packages/axiom-components/src/Menu/Menu.stories.js
+++ b/packages/axiom-components/src/Menu/Menu.stories.js
@@ -3,7 +3,7 @@ import Menu from "./Menu";
 import MenuItem from "./MenuItem";
 
 export default {
-  title: "Components/Menu",
+  title: "Menu",
   component: Menu,
   subcomponents: { MenuItem },
 };

--- a/packages/axiom-components/src/Notification/Notification.stories.js
+++ b/packages/axiom-components/src/Notification/Notification.stories.js
@@ -3,7 +3,7 @@ import Notification from "./Notification";
 import Notifications from "./Notifications";
 
 export default {
-  title: "Components/Notification",
+  title: "Notification",
   component: Notification,
 };
 

--- a/packages/axiom-components/src/Pagination/Pagination.stories.js
+++ b/packages/axiom-components/src/Pagination/Pagination.stories.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Pagination from "./Pagination";
 
 export default {
-  title: "Components/Pagination",
+  title: "Pagination",
   component: Pagination,
 };
 

--- a/packages/axiom-components/src/Pictogram/Pictogram.stories.js
+++ b/packages/axiom-components/src/Pictogram/Pictogram.stories.js
@@ -4,7 +4,7 @@ import Grid from "../Grid/Grid";
 import GridCell from "../Grid/GridCell";
 
 export default {
-  title: "Components/Pictogram",
+  title: "Pictogram",
   component: Pictogram,
 };
 

--- a/packages/axiom-components/src/Platform/Platform.stories.js
+++ b/packages/axiom-components/src/Platform/Platform.stories.js
@@ -17,7 +17,7 @@ import PlatformTitle from "./PlatformTitle";
 import Heading from "../Typography/Heading";
 
 export default {
-  title: "Components/Platform",
+  title: "Platform",
   component: Platform,
   subcomponents: {
     Dock,

--- a/packages/axiom-components/src/Position/Position.stories.js
+++ b/packages/axiom-components/src/Position/Position.stories.js
@@ -9,7 +9,7 @@ import Heading from "../Typography/Heading";
 import Toggle from "../Toggle/Toggle";
 
 export default {
-  title: "Components/Position",
+  title: "Position",
   component: Position,
   subComponents: { PositionTarget, PositionSource },
 };

--- a/packages/axiom-components/src/Progress/Progress.stories.js
+++ b/packages/axiom-components/src/Progress/Progress.stories.js
@@ -37,7 +37,7 @@ const SvgFilters = () => (
 );
 
 export default {
-  title: "Components/Progress",
+  title: "Progress",
   component: Progress,
   subcomponents: { ProgressFinite, ProgressInfinite },
   decorators: [

--- a/packages/axiom-components/src/Reveal/Reveal.stories.js
+++ b/packages/axiom-components/src/Reveal/Reveal.stories.js
@@ -5,7 +5,7 @@ import Grid from "../Grid/Grid";
 import GridCell from "../Grid/GridCell";
 
 export default {
-  title: "Components/Reveal",
+  title: "Reveal",
   component: Reveal,
 };
 

--- a/packages/axiom-components/src/Select/Select.stories.js
+++ b/packages/axiom-components/src/Select/Select.stories.js
@@ -5,7 +5,7 @@ import SelectOption from "./SelectOption";
 import { useState } from "react";
 
 export default {
-  title: "Components/Select",
+  title: "Select",
   component: Select,
 };
 const options = [

--- a/packages/axiom-components/src/Separator/Separator.stories.js
+++ b/packages/axiom-components/src/Separator/Separator.stories.js
@@ -3,7 +3,7 @@ import Separator from "./Separator";
 import { withKnobs, select } from "@storybook/addon-knobs";
 
 export default {
-  title: "Components/Separator",
+  title: "Separator",
   component: Separator,
   decorators: [
     withKnobs,

--- a/packages/axiom-components/src/Slider/Slider.stories.js
+++ b/packages/axiom-components/src/Slider/Slider.stories.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Slider from "./Slider";
 
 export default {
-  title: "Components/Slider",
+  title: "Slider",
   component: Slider,
 };
 

--- a/packages/axiom-components/src/StatusBadge/StatusBadge.stories.js
+++ b/packages/axiom-components/src/StatusBadge/StatusBadge.stories.js
@@ -4,7 +4,7 @@ import Grid from "../Grid/Grid";
 import GridCell from "../Grid/GridCell";
 
 export default {
-  title: "Components/StatusBadge",
+  title: "StatusBadge",
   component: StatusBadge,
 };
 

--- a/packages/axiom-components/src/Table/Table.stories.js
+++ b/packages/axiom-components/src/Table/Table.stories.js
@@ -7,7 +7,7 @@ import TableCell from "./TableCell";
 import TableBody from "./TableBody";
 
 export default {
-  title: "Components/Table",
+  title: "Table",
   component: Table,
   subcomponents: {
     TableHeader,

--- a/packages/axiom-components/src/Tip/Tip.stories.js
+++ b/packages/axiom-components/src/Tip/Tip.stories.js
@@ -4,7 +4,7 @@ import AlertCard from "../AlertCard/AlertCard";
 import Base from "../Base/Base";
 
 export default {
-  title: "Components/Tip",
+  title: "Tip",
   component: Tip,
 };
 

--- a/packages/axiom-components/src/Toggle/Toggle.stories.js
+++ b/packages/axiom-components/src/Toggle/Toggle.stories.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Toggle from "./Toggle";
 
 export default {
-  title: "Components/Toggle",
+  title: "Toggle",
   component: Toggle,
 };
 

--- a/packages/axiom-components/src/Tooltip/Tooltip.stories.js
+++ b/packages/axiom-components/src/Tooltip/Tooltip.stories.js
@@ -8,7 +8,7 @@ import IconButton from "../Icon/IconButton";
 import Button from "../Button/Button";
 
 export default {
-  title: "Components/Tooltip",
+  title: "Tooltip",
   component: Tooltip,
   subcomponents: {
     TooltipTarget,

--- a/packages/axiom-components/src/Transition/Transition.stories.js
+++ b/packages/axiom-components/src/Transition/Transition.stories.js
@@ -6,7 +6,7 @@ import Icon from "../Icon/Icon";
 import "./Transition.stories.css";
 
 export default {
-  title: "Components/Transition",
+  title: "Transition",
   component: Transition,
   decorators: [(storyFn) => <WrapperComponet storyFn={storyFn} />],
 };

--- a/packages/axiom-components/src/UsageHint/UsageHint.stories.js
+++ b/packages/axiom-components/src/UsageHint/UsageHint.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import UsageHint from "./UsageHint";
 
 export default {
-  title: "Components/UsageHint",
+  title: "UsageHint",
   component: UsageHint,
 };
 

--- a/packages/axiomDocs.stories.mdx
+++ b/packages/axiomDocs.stories.mdx
@@ -1,4 +1,4 @@
-<Meta title="Intro" />
+<Meta title="Introduction" />
 
 # Axiom
 These Docs are a work in progress.


### PR DESCRIPTION
Added some Axiom styling the Storybook. Avoided using css class overrides and used the theme file where possible. I'll look for a way to use the axiom css vars in a future iteration. 

Before:
<img width="1658" alt="Screenshot 2020-05-20 at 19 17 22" src="https://user-images.githubusercontent.com/3940567/82482380-adeaad00-9ace-11ea-8daf-aeea73c946d6.png">

After
<img width="1654" alt="Screenshot 2020-05-20 at 19 17 41" src="https://user-images.githubusercontent.com/3940567/82482376-a925f900-9ace-11ea-8b94-0f4a3ee96777.png">
