### PR TITLE
fix(CheckBox): Account for element border-box in svg sizing

### DIFF
--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
@@ -80,9 +80,9 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
         className="ax-checkbox__indicator"
       >
         <svg
-          height="17"
+          height="14"
           viewBox="0 0 16 16"
-          width="17"
+          width="14"
           xmlns="http://www.w3.org/2000/svg"
         >
           <g
@@ -134,9 +134,9 @@ exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
         className="ax-checkbox__indicator"
       >
         <svg
-          height="17"
+          height="14"
           viewBox="0 0 16 16"
-          width="17"
+          width="14"
           xmlns="http://www.w3.org/2000/svg"
         >
           <g
@@ -189,9 +189,9 @@ exports[`ContextMenuItem renders with multiSelect and title 1`] = `
         className="ax-checkbox__indicator"
       >
         <svg
-          height="17"
+          height="14"
           viewBox="0 0 16 16"
-          width="17"
+          width="14"
           xmlns="http://www.w3.org/2000/svg"
         >
           <g

--- a/packages/axiom-components/src/Form/Tick.js
+++ b/packages/axiom-components/src/Form/Tick.js
@@ -4,8 +4,8 @@ export default function Tick() {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="17"
-      height="17"
+      width="14"
+      height="14"
       viewBox="0 0 16 16"
     >
       <g fill="none" fillRule="evenodd" stroke="none" strokeWidth="1">

--- a/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
@@ -13,9 +13,9 @@ exports[`CheckBox renders with defaultProps 1`] = `
     className="ax-checkbox__indicator"
   >
     <svg
-      height="17"
+      height="14"
       viewBox="0 0 16 16"
-      width="17"
+      width="14"
       xmlns="http://www.w3.org/2000/svg"
     >
       <g
@@ -58,9 +58,9 @@ exports[`CheckBox renders with disabled 1`] = `
     className="ax-checkbox__indicator"
   >
     <svg
-      height="17"
+      height="14"
       viewBox="0 0 16 16"
-      width="17"
+      width="14"
       xmlns="http://www.w3.org/2000/svg"
     >
       <g
@@ -102,9 +102,9 @@ exports[`CheckBox renders with indeterminate 1`] = `
     className="ax-checkbox__indicator"
   >
     <svg
-      height="17"
+      height="14"
       viewBox="0 0 16 16"
-      width="17"
+      width="14"
       xmlns="http://www.w3.org/2000/svg"
     >
       <g
@@ -146,9 +146,9 @@ exports[`CheckBox renders with indeterminate and checked 1`] = `
     className="ax-checkbox__indicator"
   >
     <svg
-      height="17"
+      height="14"
       viewBox="0 0 16 16"
-      width="17"
+      width="14"
       xmlns="http://www.w3.org/2000/svg"
     >
       <g
@@ -190,9 +190,9 @@ exports[`CheckBox renders with invalid 1`] = `
     className="ax-checkbox__indicator"
   >
     <svg
-      height="17"
+      height="14"
       viewBox="0 0 16 16"
-      width="17"
+      width="14"
       xmlns="http://www.w3.org/2000/svg"
     >
       <g

--- a/packages/axiom-components/src/Form/__snapshots__/CheckBoxGroup.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/CheckBoxGroup.test.js.snap
@@ -16,9 +16,9 @@ exports[`CheckBox renders with defaultProps 1`] = `
       className="ax-checkbox__indicator"
     >
       <svg
-        height="17"
+        height="14"
         viewBox="0 0 16 16"
-        width="17"
+        width="14"
         xmlns="http://www.w3.org/2000/svg"
       >
         <g


### PR DESCRIPTION
There was a bug in storybook that reset the border box on elements. This caused the checkbox to be correctly centred. When the storybook bug was fixed the check box broke.

The height of the checkbox and SVG are both now 14 + border 1 + border 1 = 16px/1rem