### PR TITLE
Word wrap table headers

### DIFF
--- a/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.js
+++ b/packages/axiom-components/src/EllipsisTooltip/EllipsisTooltip.js
@@ -10,7 +10,11 @@ import TooltipTarget from "../Tooltip/TooltipTarget";
 
 function elementHasEllipsis(ref = {}) {
   const { current } = ref;
-  return current && current.scrollWidth > current.clientWidth;
+  return (
+    current &&
+    (current.scrollWidth > current.clientWidth ||
+      current.scrollHeight > current.clientHeight)
+  );
 }
 
 export default class EllipsisTooltip extends Component {

--- a/packages/axiom-components/src/Table/Table.css
+++ b/packages/axiom-components/src/Table/Table.css
@@ -155,6 +155,15 @@
   width: 1%;
 }
 
+/* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */
+.ax-table__header-tooltip--wrap {
+  display: -webkit-box;
+  white-space: normal;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+/* stylelint-enable value-no-vendor-prefix, property-no-vendor-prefix  */
+
 .ax-table__row {
   transition-property: background-color;
   transition-duration: var(--transition-time-base);

--- a/packages/axiom-components/src/Table/Table.stories.js
+++ b/packages/axiom-components/src/Table/Table.stories.js
@@ -24,7 +24,9 @@ export function Default() {
       <TableHeader>
         <TableHeaderLabel sortDirection="ascending">Column A</TableHeaderLabel>
         <TableHeaderLabel>Column B</TableHeaderLabel>
-        <TableHeaderLabel>Column C</TableHeaderLabel>
+        <TableHeaderLabel wrap={true}>
+          Super long Column C label with wrapping Lorem ipsum
+        </TableHeaderLabel>
         <TableHeaderLabel>Column D</TableHeaderLabel>
       </TableHeader>
       <TableBody>

--- a/packages/axiom-components/src/Table/TableHeaderLabel.js
+++ b/packages/axiom-components/src/Table/TableHeaderLabel.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import classnames from "classnames";
 import Base from "../Base/Base";
 import TextIcon from "../Typography/TextIcon";
+import EllipsisTooltip from "../EllipsisTooltip/EllipsisTooltip";
 
 export default class TableHeaderLabel extends Component {
   static propTypes = {
@@ -24,11 +25,14 @@ export default class TableHeaderLabel extends Component {
     textAlign: PropTypes.oneOf(["left", "right", "centre"]),
     /** Set percentage column width (Incompatible with 'grow' and 'shink') */
     width: PropTypes.number,
+    /** Allow label text wrapping */
+    wrap: PropTypes.bool,
   };
 
   static defaultProps = {
     textAlign: "left",
     sortable: true,
+    wrap: false,
   };
 
   render() {
@@ -42,6 +46,7 @@ export default class TableHeaderLabel extends Component {
       textAlign,
       sortable,
       width,
+      wrap,
       ...rest
     } = this.props;
 
@@ -62,13 +67,19 @@ export default class TableHeaderLabel extends Component {
 
     return (
       <Base {...rest} Component="th" className={classes} style={styles}>
-        <button
+        <div
           className="ax-table__header-button"
           disabled={!onClick}
           onClick={onClick}
+          role="button"
         >
-          {children}
-
+          {wrap ? (
+            <EllipsisTooltip className="ax-table__header-tooltip--wrap">
+              {children}
+            </EllipsisTooltip>
+          ) : (
+            children
+          )}
           {sortable && (
             <TextIcon
               cloak={sortDirection === undefined}
@@ -79,7 +90,7 @@ export default class TableHeaderLabel extends Component {
               spaceRight={textAlign === "right" ? "x2" : undefined}
             />
           )}
-        </button>
+        </div>
       </Base>
     );
   }

--- a/packages/axiom-components/src/Table/TableHeaderLabel.test.js
+++ b/packages/axiom-components/src/Table/TableHeaderLabel.test.js
@@ -48,6 +48,12 @@ describe("TableHeaderLabel", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it("renders with wrap", () => {
+    const component = getComponent({ wrap: true });
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it("width overrides grow", () => {
     const component = getComponent({ width: 20, grow: true });
     const tree = component.toJSON();

--- a/packages/axiom-components/src/Table/__snapshots__/TableHeader.test.js.snap
+++ b/packages/axiom-components/src/Table/__snapshots__/TableHeader.test.js.snap
@@ -8,9 +8,10 @@ exports[`TableHeader renders 1`] = `
     <th
       className="ax-table__header-label ax-table__header-label--align-left"
     >
-      <button
+      <div
         className="ax-table__header-button"
         disabled={true}
+        role="button"
       >
         Test
         <svg
@@ -28,7 +29,7 @@ exports[`TableHeader renders 1`] = `
           }
           viewBox="0 0 16 16"
         />
-      </button>
+      </div>
     </th>
   </tr>
 </thead>

--- a/packages/axiom-components/src/Table/__snapshots__/TableHeaderLabel.test.js.snap
+++ b/packages/axiom-components/src/Table/__snapshots__/TableHeaderLabel.test.js.snap
@@ -4,9 +4,10 @@ exports[`TableHeaderLabel renders 1`] = `
 <th
   className="ax-table__header-label ax-table__header-label--align-left"
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -24,7 +25,7 @@ exports[`TableHeaderLabel renders 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
 </th>
 `;
 
@@ -32,9 +33,10 @@ exports[`TableHeaderLabel renders with grow 1`] = `
 <th
   className="ax-table__header-label ax-table__header-label--align-left ax-table__header-label--grow"
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -52,7 +54,7 @@ exports[`TableHeaderLabel renders with grow 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
 </th>
 `;
 
@@ -60,9 +62,10 @@ exports[`TableHeaderLabel renders with shrink 1`] = `
 <th
   className="ax-table__header-label ax-table__header-label--align-left ax-table__header-label--shrink"
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -80,7 +83,7 @@ exports[`TableHeaderLabel renders with shrink 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
 </th>
 `;
 
@@ -88,9 +91,10 @@ exports[`TableHeaderLabel renders with sortDirection 1`] = `
 <th
   className="ax-table__header-label ax-table__header-label--align-left ax-table__header-label--selected"
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -108,7 +112,7 @@ exports[`TableHeaderLabel renders with sortDirection 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
 </th>
 `;
 
@@ -116,12 +120,13 @@ exports[`TableHeaderLabel renders with sortable 1`] = `
 <th
   className="ax-table__header-label ax-table__header-label--align-left"
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
-  </button>
+  </div>
 </th>
 `;
 
@@ -129,9 +134,10 @@ exports[`TableHeaderLabel renders with textAlign 1`] = `
 <th
   className="ax-table__header-label ax-table__header-label--align-right"
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -149,7 +155,7 @@ exports[`TableHeaderLabel renders with textAlign 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
 </th>
 `;
 
@@ -162,9 +168,10 @@ exports[`TableHeaderLabel renders with width 1`] = `
     }
   }
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -182,7 +189,41 @@ exports[`TableHeaderLabel renders with width 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
+</th>
+`;
+
+exports[`TableHeaderLabel renders with wrap 1`] = `
+<th
+  className="ax-table__header-label ax-table__header-label--align-left"
+>
+  <div
+    className="ax-table__header-button"
+    disabled={true}
+    role="button"
+  >
+    <div
+      className="ax-table__header-tooltip--wrap ax-text--ellipsis"
+      onMouseOver={[Function]}
+    >
+      Test
+    </div>
+    <svg
+      className="ax-icon ax-icon--triangle-up ax-icon--inline ax-icon--space-left-x2 ax-cloak"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<path d=\\"M13 12L7.93 4 3 12z\\" fill=\\"currentColor\\" fill-rule=\\"evenodd\\"/>",
+        }
+      }
+      style={
+        Object {
+          "height": "1rem",
+          "width": "1rem",
+        }
+      }
+      viewBox="0 0 16 16"
+    />
+  </div>
 </th>
 `;
 
@@ -195,9 +236,10 @@ exports[`TableHeaderLabel width overrides grow 1`] = `
     }
   }
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -215,7 +257,7 @@ exports[`TableHeaderLabel width overrides grow 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
 </th>
 `;
 
@@ -228,9 +270,10 @@ exports[`TableHeaderLabel width overrides shrink 1`] = `
     }
   }
 >
-  <button
+  <div
     className="ax-table__header-button"
     disabled={true}
+    role="button"
   >
     Test
     <svg
@@ -248,6 +291,6 @@ exports[`TableHeaderLabel width overrides shrink 1`] = `
       }
       viewBox="0 0 16 16"
     />
-  </button>
+  </div>
 </th>
 `;


### PR DESCRIPTION
This PR allows us to have wrappable table headers. After consultation with @Flawwles, it was decided to limit the number of possible lines to 2.

As noted in the commit message, to achieve this I've used the `line-clamp` property.

![image](https://user-images.githubusercontent.com/1177870/88079213-5079e780-cb75-11ea-9b2e-fe2845e8fe8b.png)
