### PR TITLE
fix: Checkbox disabled/indeterminate states

### DIFF
--- a/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
+++ b/packages/axiom-components/src/Context/__snapshots__/ContextMenuItem.test.js.snap
@@ -78,31 +78,7 @@ exports[`ContextMenuItem renders with multiSelect 1`] = `
       />
       <span
         className="ax-checkbox__indicator"
-      >
-        <svg
-          height="14"
-          viewBox="0 0 16 16"
-          width="14"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <g
-              fillRule="nonzero"
-              stroke="white"
-              strokeWidth="2.1"
-            >
-              <path
-                d="M3.25 8.25L6 11l6.75-6.75"
-              />
-            </g>
-          </g>
-        </svg>
-      </span>
+      />
     </label>
   </div>
   <div
@@ -146,6 +122,7 @@ exports[`ContextMenuItem renders with multiSelect and selected 1`] = `
             strokeWidth="1"
           >
             <g
+              className="tick"
               fillRule="nonzero"
               stroke="white"
               strokeWidth="2.1"
@@ -187,31 +164,7 @@ exports[`ContextMenuItem renders with multiSelect and title 1`] = `
       />
       <span
         className="ax-checkbox__indicator"
-      >
-        <svg
-          height="14"
-          viewBox="0 0 16 16"
-          width="14"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fillRule="evenodd"
-            stroke="none"
-            strokeWidth="1"
-          >
-            <g
-              fillRule="nonzero"
-              stroke="white"
-              strokeWidth="2.1"
-            >
-              <path
-                d="M3.25 8.25L6 11l6.75-6.75"
-              />
-            </g>
-          </g>
-        </svg>
-      </span>
+      />
     </label>
   </div>
   <div

--- a/packages/axiom-components/src/Form/CheckBox.stories.js
+++ b/packages/axiom-components/src/Form/CheckBox.stories.js
@@ -8,21 +8,25 @@ export default {
   component: CheckBox,
 };
 
-export function Default() {
-  const [checked, setChecked] = useState(false);
+export function Default({ children, checked, ...rest }) {
+  const [isChecked, setChecked] = useState(checked);
+
   return (
     <CheckBoxGroup>
       <CheckBox
-        checked={checked}
+        checked={isChecked}
         name="lorem"
         onChange={() => setChecked((c) => !c)}
         title="Lorem ipsum dolor sit amet"
+        {...rest}
       >
-        Lorem ipsum
+        {children}
       </CheckBox>
     </CheckBoxGroup>
   );
 }
+
+Default.args = { children: "Lorem ipsum", checked: false };
 
 export function CheckBoxGroups() {
   const ToggableCheckBox = ({ children }) => {

--- a/packages/axiom-components/src/Form/ChedioButtox.css
+++ b/packages/axiom-components/src/Form/ChedioButtox.css
@@ -145,3 +145,7 @@
 .ax-checkbox--disabled .tick {
   stroke: var(--color-theme-border);
 }
+
+.ax-checkbox--disabled .indeterminate {
+  fill: var(--color-theme-border);
+}

--- a/packages/axiom-components/src/Form/ChedioButtox.css
+++ b/packages/axiom-components/src/Form/ChedioButtox.css
@@ -142,21 +142,6 @@
   }
 }
 
-.ax-checkbox__indicator::before {
-  @nest .ax-checkbox__input + & { border-color: transparent; }
-  @nest .ax-checkbox__input:checked + & { border-color: var(--color-ui-white-noise); }
-  @nest .ax-checkbox__input:checked:active:enabled + & { border-color: var(--color-ui-accent); }
-  @nest .ax-checkbox__input:disabled + & { border-color: transparent; }
-  @nest .ax-checkbox__input:disabled:checked + & { border-color: var(--color-theme-border); }
-  @nest .ax-checkbox--indeterminate & {
-    top: var(--cmp-checkbox-indeterminate-top);
-    right: var(--cmp-checkbox-indeterminate-horizontal);
-    left: var(--cmp-checkbox-indeterminate-horizontal);
-    transform: rotate(0deg);
-    border-left: 0;
-  }
-
-  @nest .ax-checkbox--invalid .ax-checkbox__input:checked:active:enabled + & {
-    border-color: var(--color-ui-error);
-  }
+.ax-checkbox--disabled .tick {
+  stroke: var(--color-theme-border);
 }

--- a/packages/axiom-components/src/Form/ChedioButtox.js
+++ b/packages/axiom-components/src/Form/ChedioButtox.js
@@ -8,6 +8,7 @@ import "./ChedioButtox.css";
 
 export default class ChedioButtox extends Component {
   static propTypes = {
+    checked: PropTypes.bool,
     children: PropTypes.node,
     className: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
@@ -28,6 +29,7 @@ export default class ChedioButtox extends Component {
       title,
       onClick,
       indeterminate,
+      checked,
       ...rest
     } = this.props;
 
@@ -57,13 +59,14 @@ export default class ChedioButtox extends Component {
       >
         <input
           {...rest}
+          checked={checked}
           className={`${className}__input`}
           disabled={disabled}
           type={inputType}
         />
 
         <span className={`${className}__indicator`}>
-          {inputType === "checkbox" && <Tick />}
+          {inputType === "checkbox" && checked && <Tick />}
         </span>
         {children && <span className={`${className}__label`}>{children}</span>}
       </Base>

--- a/packages/axiom-components/src/Form/ChedioButtox.js
+++ b/packages/axiom-components/src/Form/ChedioButtox.js
@@ -3,73 +3,80 @@ import React, { Component } from "react";
 import classnames from "classnames";
 import Base from "../Base/Base";
 import Tick from "./Tick";
+import Indeterminate from "./Indeterminate";
 
 import "./ChedioButtox.css";
 
-export default class ChedioButtox extends Component {
-  static propTypes = {
-    checked: PropTypes.bool,
-    children: PropTypes.node,
-    className: PropTypes.string.isRequired,
-    disabled: PropTypes.bool,
-    indeterminate: PropTypes.bool,
-    inputType: PropTypes.oneOf(["checkbox", "radio"]).isRequired,
-    invalid: PropTypes.bool,
-    onClick: PropTypes.func,
-    title: PropTypes.string,
+export default function ChedioButtox({
+  children,
+  className,
+  disabled,
+  inputType,
+  invalid,
+  title,
+  onClick,
+  indeterminate,
+  checked,
+  ...rest
+}) {
+  const getMarker = () => {
+    if (indeterminate) {
+      return <Indeterminate />;
+    }
+
+    if (checked) {
+      return <Tick />;
+    }
   };
 
-  render() {
-    const {
-      children,
-      className,
-      disabled,
-      inputType,
-      invalid,
-      title,
-      onClick,
-      indeterminate,
-      checked,
-      ...rest
-    } = this.props;
-
-    const classes = classnames(className, {
-      [`${className}--disabled`]: disabled,
-      [`${className}--invalid`]: invalid,
-      [`${className}--indeterminate`]: indeterminate,
+  const handleClick =
+    onClick &&
+    ((e) => {
+      if (e.target.tagName !== "INPUT") {
+        e.stopPropagation();
+        return;
+      }
+      onClick(e);
     });
 
-    const handleClick =
-      onClick &&
-      ((e) => {
-        if (e.target.tagName !== "INPUT") {
-          e.stopPropagation();
-          return;
-        }
-        onClick(e);
-      });
+  const classes = classnames(className, {
+    [`${className}--disabled`]: disabled,
+    [`${className}--invalid`]: invalid,
+    [`${className}--indeterminate`]: indeterminate,
+  });
 
-    return (
-      <Base
-        Component="label"
-        className={classes}
-        onClick={handleClick}
-        space="x2"
-        title={title}
-      >
-        <input
-          {...rest}
-          checked={checked}
-          className={`${className}__input`}
-          disabled={disabled}
-          type={inputType}
-        />
+  return (
+    <Base
+      Component="label"
+      className={classes}
+      onClick={handleClick}
+      space="x2"
+      title={title}
+    >
+      <input
+        {...rest}
+        checked={checked}
+        className={`${className}__input`}
+        disabled={disabled}
+        type={inputType}
+      />
 
-        <span className={`${className}__indicator`}>
-          {inputType === "checkbox" && checked && <Tick />}
-        </span>
-        {children && <span className={`${className}__label`}>{children}</span>}
-      </Base>
-    );
-  }
+      <span className={`${className}__indicator`}>
+        {inputType === "checkbox" && getMarker()}
+      </span>
+      {children && <span className={`${className}__label`}>{children}</span>}
+    </Base>
+  );
 }
+
+ChedioButtox.propTypes = {
+  checked: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  indeterminate: PropTypes.bool,
+  inputType: PropTypes.oneOf(["checkbox", "radio"]).isRequired,
+  invalid: PropTypes.bool,
+  onClick: PropTypes.func,
+  title: PropTypes.string,
+};

--- a/packages/axiom-components/src/Form/Indeterminate.js
+++ b/packages/axiom-components/src/Form/Indeterminate.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+export default function Indeterminate() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+    >
+      <path
+        className="indeterminate"
+        fill="white"
+        fillRule="evenodd"
+        d="M3 7h10v2H3z"
+      />
+    </svg>
+  );
+}

--- a/packages/axiom-components/src/Form/Tick.js
+++ b/packages/axiom-components/src/Form/Tick.js
@@ -9,7 +9,7 @@ export default function Tick() {
       viewBox="0 0 16 16"
     >
       <g fill="none" fillRule="evenodd" stroke="none" strokeWidth="1">
-        <g fillRule="nonzero" stroke="white" strokeWidth="2.1">
+        <g className="tick" fillRule="nonzero" stroke="white" strokeWidth="2.1">
           <path d="M3.25 8.25L6 11l6.75-6.75"></path>
         </g>
       </g>

--- a/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
@@ -59,23 +59,12 @@ exports[`CheckBox renders with indeterminate 1`] = `
       width="14"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <g
-        fill="none"
+      <path
+        className="indeterminate"
+        d="M3 7h10v2H3z"
+        fill="white"
         fillRule="evenodd"
-        stroke="none"
-        strokeWidth="1"
-      >
-        <g
-          className="tick"
-          fillRule="nonzero"
-          stroke="white"
-          strokeWidth="2.1"
-        >
-          <path
-            d="M3.25 8.25L6 11l6.75-6.75"
-          />
-        </g>
-      </g>
+      />
     </svg>
   </span>
   <span

--- a/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/CheckBox.test.js.snap
@@ -11,31 +11,7 @@ exports[`CheckBox renders with defaultProps 1`] = `
   />
   <span
     className="ax-checkbox__indicator"
-  >
-    <svg
-      height="14"
-      viewBox="0 0 16 16"
-      width="14"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fill="none"
-        fillRule="evenodd"
-        stroke="none"
-        strokeWidth="1"
-      >
-        <g
-          fillRule="nonzero"
-          stroke="white"
-          strokeWidth="2.1"
-        >
-          <path
-            d="M3.25 8.25L6 11l6.75-6.75"
-          />
-        </g>
-      </g>
-    </svg>
-  </span>
+  />
   <span
     className="ax-checkbox__label"
   >
@@ -56,31 +32,7 @@ exports[`CheckBox renders with disabled 1`] = `
   />
   <span
     className="ax-checkbox__indicator"
-  >
-    <svg
-      height="14"
-      viewBox="0 0 16 16"
-      width="14"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fill="none"
-        fillRule="evenodd"
-        stroke="none"
-        strokeWidth="1"
-      >
-        <g
-          fillRule="nonzero"
-          stroke="white"
-          strokeWidth="2.1"
-        >
-          <path
-            d="M3.25 8.25L6 11l6.75-6.75"
-          />
-        </g>
-      </g>
-    </svg>
-  </span>
+  />
   <span
     className="ax-checkbox__label"
   >
@@ -114,6 +66,7 @@ exports[`CheckBox renders with indeterminate 1`] = `
         strokeWidth="1"
       >
         <g
+          className="tick"
           fillRule="nonzero"
           stroke="white"
           strokeWidth="2.1"
@@ -158,6 +111,7 @@ exports[`CheckBox renders with indeterminate and checked 1`] = `
         strokeWidth="1"
       >
         <g
+          className="tick"
           fillRule="nonzero"
           stroke="white"
           strokeWidth="2.1"
@@ -188,31 +142,7 @@ exports[`CheckBox renders with invalid 1`] = `
   />
   <span
     className="ax-checkbox__indicator"
-  >
-    <svg
-      height="14"
-      viewBox="0 0 16 16"
-      width="14"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g
-        fill="none"
-        fillRule="evenodd"
-        stroke="none"
-        strokeWidth="1"
-      >
-        <g
-          fillRule="nonzero"
-          stroke="white"
-          strokeWidth="2.1"
-        >
-          <path
-            d="M3.25 8.25L6 11l6.75-6.75"
-          />
-        </g>
-      </g>
-    </svg>
-  </span>
+  />
   <span
     className="ax-checkbox__label"
   >

--- a/packages/axiom-components/src/Form/__snapshots__/CheckBoxGroup.test.js.snap
+++ b/packages/axiom-components/src/Form/__snapshots__/CheckBoxGroup.test.js.snap
@@ -14,31 +14,7 @@ exports[`CheckBox renders with defaultProps 1`] = `
     />
     <span
       className="ax-checkbox__indicator"
-    >
-      <svg
-        height="14"
-        viewBox="0 0 16 16"
-        width="14"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <g
-          fill="none"
-          fillRule="evenodd"
-          stroke="none"
-          strokeWidth="1"
-        >
-          <g
-            fillRule="nonzero"
-            stroke="white"
-            strokeWidth="2.1"
-          >
-            <path
-              d="M3.25 8.25L6 11l6.75-6.75"
-            />
-          </g>
-        </g>
-      </svg>
-    </span>
+    />
     <span
       className="ax-checkbox__label"
     >


### PR DESCRIPTION
Fixes #925 

When making the tick mark an SVG i broke the disabled styles this PR fixed that.

Un-Checked Disabled
<img width="134" alt="Screenshot 2020-07-28 at 22 41 29" src="https://user-images.githubusercontent.com/3940567/88725139-8c87ec00-d123-11ea-887a-b113ef964e6f.png">

Checked Disabled 
<img width="117" alt="Screenshot 2020-07-28 at 22 41 16" src="https://user-images.githubusercontent.com/3940567/88725176-9c9fcb80-d123-11ea-81e1-5247558126bc.png">

Indeterminate
<img width="141" alt="Screenshot 2020-07-29 at 15 41 09" src="https://user-images.githubusercontent.com/3940567/88814595-357d2800-d1b2-11ea-969a-b68fe73777e2.png">
Indeterminate - disabled
<img width="128" alt="Screenshot 2020-07-29 at 15 41 27" src="https://user-images.githubusercontent.com/3940567/88814581-30b87400-d1b2-11ea-979b-56237ea44ae5.png">
Indeterminate - invalid
<img width="130" alt="Screenshot 2020-07-29 at 15 41 22" src="https://user-images.githubusercontent.com/3940567/88814590-33b36480-d1b2-11ea-83ce-0bf778dd6731.png">


