### PR TITLE
fix: keep original values if transformed values or step not finite

### DIFF
--- a/packages/axiom-components/src/Slider/Range.js
+++ b/packages/axiom-components/src/Slider/Range.js
@@ -88,6 +88,9 @@ export default class Range extends Component {
   ensureValueInRange(value) {
     const { min, max, step } = this.props;
     const valueInRange = Math.max(min, Math.min(value, max));
+    if (!isFinite(valueInRange) || !isFinite(step)) {
+      return value;
+    }
     return step * Math.round(valueInRange / step);
   }
 

--- a/packages/axiom-components/src/Slider/Range.test.js
+++ b/packages/axiom-components/src/Slider/Range.test.js
@@ -19,6 +19,10 @@ const getComponent = (props = {}) => {
 jest.mock("../Position/Position");
 
 describe("Range", () => {
+  beforeEach(() => {
+    requiredProps.onChange.mockClear();
+  });
+
   it("renders with defaultProps", () => {
     const component = getComponent();
     const tree = component.toJSON();
@@ -45,6 +49,16 @@ describe("Range", () => {
     });
 
     expect(requiredProps.onChange).toHaveBeenCalledWith([0, 1]);
+  });
+
+  it("doesn't reset its values when min and max are infinite", () => {
+    getComponent({
+      min: Infinity,
+      max: -Infinity,
+      values: [-1.5, 2.4],
+    });
+
+    expect(requiredProps.onChange).toHaveBeenCalledTimes(0);
   });
 
   describe("withBoundingClientRect", () => {

--- a/packages/axiom-components/src/Slider/__snapshots__/Range.test.js.snap
+++ b/packages/axiom-components/src/Slider/__snapshots__/Range.test.js.snap
@@ -24,21 +24,11 @@ exports[`Range renders with custom props 1`] = `
               Array [
                 Array [
                   3,
-                  13,
-                ],
-              ],
-              Array [
-                Array [
-                  3,
                   12.600000000000001,
                 ],
               ],
             ],
             "results": Array [
-              Object {
-                "type": "return",
-                "value": undefined,
-              },
               Object {
                 "type": "return",
                 "value": undefined,


### PR DESCRIPTION
[![SN-242](https://badgen.net/badge/JIRA/SN-242/0052CC)](https://office.brandwatch.com/jira/browse/SN-242) 

By ensuring values are in within the bounds of the Range slider, we did not take care of edge cases like for example when `min` and `max` have infinite values (the min and max bounds are sometimes set dynamically). This resulted in the new values being set to `NaN` which in turn was disabling the Range slider when `min` and `max` bounds were reset to finite numbers.

This PR fixes this undesired behaviour by not adjusting the slider values when the new values would not be finite (NaN for example).