### PR TITLE
NOTICKET Enable inlining UsageHint

### DIFF
--- a/packages/axiom-components/src/UsageHint/UsageHint.js
+++ b/packages/axiom-components/src/UsageHint/UsageHint.js
@@ -17,22 +17,24 @@ export default class UsageHint extends PureComponent {
     children: PropTypes.node,
     position: PropTypes.oneOf(["top", "bottom", "left", "right"]),
     showArrow: PropTypes.bool,
+    inline: PropTypes.bool,
     /** Total width of the usageHint dropdown context */
     width: PropTypes.string,
   };
 
   static defaultProps = {
     showArrow: true,
+    inline: false,
   };
 
   render() {
-    const { children, width, ...rest } = this.props;
+    const { children, inline, width, ...rest } = this.props;
 
     return (
       <Dropdown {...rest} showArrow>
         <DropdownTarget>
           <Link style="subtle">
-            <Icon name="question-mark-circle" size="1rem" />
+            <Icon inline={inline} name="question-mark-circle" size="1rem" />
           </Link>
         </DropdownTarget>
         <DropdownSource>


### PR DESCRIPTION
I noticed that the UsageHint is effectively using the Icon component (which accepts the inline prop) but doesn't support the inline prop. This is something that we could use in the QueryBuilder to inline the UsageHint with the text (can also be done with Grid, but thought this is nicer).