### PR TITLE
style: 💄 Adds secondary style to ProgressButton

### DIFF
--- a/packages/axiom-components/src/Button/Button.stories.js
+++ b/packages/axiom-components/src/Button/Button.stories.js
@@ -123,12 +123,22 @@ export function Progress() {
   const [isInProgress, setIsInProgress] = useState(true);
 
   return (
-    <ProgressButton
-      isInProgress={isInProgress}
-      onClick={() => setIsInProgress((p) => !p)}
-    >
-      Submit
-    </ProgressButton>
+    <ButtonGroup>
+      <ProgressButton
+        isInProgress={isInProgress}
+        onClick={() => setIsInProgress((p) => !p)}
+        variant="primary"
+      >
+        Submit
+      </ProgressButton>
+      <ProgressButton
+        isInProgress={isInProgress}
+        onClick={() => setIsInProgress((p) => !p)}
+        variant="secondary"
+      >
+        Submit
+      </ProgressButton>
+    </ButtonGroup>
   );
 }
 

--- a/packages/axiom-components/src/Progress/ProgressButton.js
+++ b/packages/axiom-components/src/Progress/ProgressButton.js
@@ -12,6 +12,11 @@ const progressSizeMap = {
   large: "1.5rem",
 };
 
+const progressColorMap = {
+  primary: "white",
+  secondary: "subtle",
+};
+
 export default class ProgressButton extends Component {
   static propTypes = {
     /** Content to be inserted into the Button */
@@ -20,6 +25,8 @@ export default class ProgressButton extends Component {
     isInProgress: PropTypes.bool,
     /** Size of the Button. See Button[size]. */
     size: PropTypes.oneOf(["small", "medium", "large"]),
+    /** variant of the Button, which affects its coloring and sizing */
+    variant: PropTypes.oneOf(["primary", "secondary"]),
   };
 
   render() {
@@ -27,6 +34,7 @@ export default class ProgressButton extends Component {
       children,
       isInProgress,
       size = Button.defaultProps.size,
+      variant = Button.defaultProps.variant,
       ...rest
     } = this.props;
 
@@ -35,7 +43,7 @@ export default class ProgressButton extends Component {
     });
 
     return (
-      <Button {...rest} active={isInProgress} size={size} variant="primary">
+      <Button {...rest} active={isInProgress} size={size} variant={variant}>
         <div className={classes}>
           <Cloak
             className="ax-progress-button__content"
@@ -48,7 +56,10 @@ export default class ProgressButton extends Component {
             className="ax-progress-button__indicator"
             invisible={!isInProgress}
           >
-            <ProgressInfinite color="white" sizeRem={progressSizeMap[size]} />
+            <ProgressInfinite
+              color={progressColorMap[variant]}
+              sizeRem={progressSizeMap[size]}
+            />
           </Cloak>
         </div>
       </Button>


### PR DESCRIPTION
I like progress buttons. 

Since `Progress` already accepts a color prop of subtle (was using white which matched `primary` well) I thought I'd add support for the `ProgressButton` to be `secondary` as well. Wouldn't really make sense to enable other variants as they essentially don't have backgrounds. 

Let me know what you think.