### PR TITLE
Text input classname

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -37,6 +37,7 @@ addParameters({
       order: [
         "Introduction",
         "Getting Started",
+        "Customising Axiom",
         "Colors & Themes",
         "Typography",
       ],

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -14,6 +14,7 @@ export default class TextInput extends Component {
   static propTypes = {
     /** Optional TextInputIcon or TextInputButton all other children are ignored */
     children: PropTypes.node,
+    /** Class applied to input container*/
     className: PropTypes.string,
     /** Disables interactions and applies styling */
     disabled: PropTypes.bool,
@@ -21,6 +22,8 @@ export default class TextInput extends Component {
     error: PropTypes.func,
     /** Display label inline */
     inlineLabel: PropTypes.bool,
+    /** Class applied to input element */
+    inputClassName: PropTypes.string,
     /** Pass this prop to get ref to the Text Component instance. */
     inputRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     /** Applies styling to indicate the users input was invalid */
@@ -121,6 +124,7 @@ export default class TextInput extends Component {
       disabled,
       error,
       valid,
+      inputClassName,
       invalid,
       isInProgress,
       isTarget,
@@ -148,6 +152,7 @@ export default class TextInput extends Component {
     const showIcon = icon && (!isInProgress || icon.props.align === "left");
 
     const inputContainerclasses = classnames("ax-input__container", className);
+    const inputclasses = classnames("ax-input", inputClassName);
 
     return (
       <Validate
@@ -182,7 +187,7 @@ export default class TextInput extends Component {
                 {...rest}
                 Component="input"
                 baseRef={inputRef}
-                className="ax-input"
+                className={inputclasses}
                 disabled={disabled}
                 onBlur={this.handleOnBlur.bind(this)}
                 onFocus={this.handleOnFocus.bind(this)}

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-
+import classnames from "classnames";
 import { findComponent } from "@brandwatch/axiom-utils";
 import Base from "../Base/Base";
 import Validate from "../Validation/Validate";
@@ -14,6 +14,7 @@ export default class TextInput extends Component {
   static propTypes = {
     /** Optional TextInputIcon or TextInputButton all other children are ignored */
     children: PropTypes.node,
+    className: PropTypes.string,
     /** Disables interactions and applies styling */
     disabled: PropTypes.bool,
     /** See Validate[error] */
@@ -116,6 +117,7 @@ export default class TextInput extends Component {
   render() {
     const {
       children,
+      className,
       disabled,
       error,
       valid,
@@ -145,6 +147,8 @@ export default class TextInput extends Component {
     const showOnClear = onClear && value && !isInProgress;
     const showIcon = icon && (!isInProgress || icon.props.align === "left");
 
+    const inputContainerclasses = classnames("ax-input__container", className);
+
     return (
       <Validate
         error={error}
@@ -153,7 +157,7 @@ export default class TextInput extends Component {
         value={value}
       >
         {(isValid) => (
-          <Base className="ax-input__container" space={space}>
+          <Base className={inputContainerclasses} space={space}>
             <InputWrapper
               disabled={disabled}
               hasFocus={hasFocus}

--- a/packages/axiom-components/src/Form/TextInput.stories.js
+++ b/packages/axiom-components/src/Form/TextInput.stories.js
@@ -11,8 +11,8 @@ export default {
   subcomponents: { TextInputButton, TextInputIcon },
 };
 
-export function Default() {
-  return <TextInput />;
+export function Default(args) {
+  return <TextInput {...args} />;
 }
 
 export function OnChange() {
@@ -87,7 +87,7 @@ export function WithRef() {
   const inputRef = useRef();
 
   useEffect(() => {
-    inputRef.current?.focus();
+    inputRef.current.value = "Added with a ref";
   }, [inputRef.current]);
 
   return (

--- a/packages/customisingAxiom.stories.mdx
+++ b/packages/customisingAxiom.stories.mdx
@@ -1,0 +1,46 @@
+<Meta title="Customising Axiom" />
+
+# Customising Axiom
+
+Axiom aims to cover the vast majority of use cases but inevitably there will be times when you need to implement a behaviour or style that Axiom does not support. 
+When this occurs you have a few options, we would ask before considering these options you reach out to us so we can consider updating Axiom to support more use cases.
+
+<br /> 
+
+## Custom CSS classNames
+Nearly all components now support custom ClassNames being passed, please raise a PR or issue if you find one that does not. 
+These classnames will then be rendered in the final DOM output e.g
+
+```
+<Table className="my-nice-class"/>
+```
+
+Some components render multiple children in this case we will provide a custom prop to describe the element you want to target.
+
+```
+  <TextInput className="my-custom-class" inputClassName="my-input-class"/>
+
+  <Base className={className}>
+    <TextInput className={inputClassName} />
+  </Base>
+```
+
+## Using Axiom CSS Variables
+This feature is not yet fully documented however `@brandwatch/axiom-materials` defines utility CSS variables which can be used to compose your own components 
+or add spacing or other styles that are consistent with the Axiom designs.
+
+One common use case is to apply color or spacing e.g.
+
+```
+// app.css
+
+.box {
+  padding: var(--spacing-grid-size--x2);
+  background: var(--color-theme-background--shade-2);
+}
+
+```
+
+Exported CSS variables can be found [here](https://github.com/BrandwatchLtd/axiom-react/blob/master/packages/axiom-materials/src/importCssVariables.js)
+
+You can also use this [Code Sandbox](https://codesandbox.io/s/axiom-materials-import-importcssvariables-9mwhi) as an example template.


### PR DESCRIPTION
Implements a new pattern as discussed in #919. In future where we have elements with multiple children we might want to pass a classname to we will use a custom prob see `inputClassName` as an example. I also documented this pattern in the docs in a new "Customising Axiom" section.

- Pass ClassName to TextInput
- Add new prop to pass class to input element
- Add new docs section "Customising Axiom"