### PR TITLE
fix: Change Tab titles to be title-case to match design docs

### DIFF
--- a/packages/axiom-components/src/Tabset/Tab.stories.js
+++ b/packages/axiom-components/src/Tabset/Tab.stories.js
@@ -1,0 +1,36 @@
+import React from "react";
+import Tabset from "./Tabset";
+import Tab from "./Tab";
+
+export default {
+  title: "Tab",
+  component: Tab,
+};
+
+export function Default(props) {
+  return (
+    <Tabset>
+      <Tab title="Tab 1" {...props}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
+        libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
+        tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
+        velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
+        Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
+      </Tab>
+      <Tab title="Tab 2" {...props}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
+        libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
+        tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
+        velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
+        Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
+      </Tab>
+      <Tab title="Tab 3" {...props}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
+        libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
+        tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
+        velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
+        Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
+      </Tab>
+    </Tabset>
+  );
+}

--- a/packages/axiom-components/src/Tabset/Tabset.css
+++ b/packages/axiom-components/src/Tabset/Tabset.css
@@ -52,7 +52,7 @@
   border: 0;
   background: none;
   color: inherit;
-  text-transform: uppercase;
+  text-transform: capitalize;
   line-height: var(--component-line-height);
   transition-property: color;
   transition-duration: var(--transition-time-base);

--- a/packages/axiom-components/src/Tabset/Tabset.stories.js
+++ b/packages/axiom-components/src/Tabset/Tabset.stories.js
@@ -1,0 +1,37 @@
+import React from "react";
+import Tab from "./Tab";
+import Tabset from "./Tabset";
+
+export default {
+  title: "Tabset",
+  component: Tabset,
+  subcomponents: { Tab },
+};
+
+export function Default({ size, space, activeTabIndex }) {
+  return (
+    <Tabset size={size} space={space} activeTabIndex={activeTabIndex}>
+      <Tab title="Tab 1">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
+        libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
+        tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
+        velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
+        Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
+      </Tab>
+      <Tab title="Tab 2">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
+        libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
+        tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
+        velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
+        Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
+      </Tab>
+      <Tab title="Tab 3">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
+        libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
+        tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
+        velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
+        Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
+      </Tab>
+    </Tabset>
+  );
+}


### PR DESCRIPTION
Adds stories for Tab/Tabs closing #929 

Use Title-case for tab titles, see design docs https://gallery.io/projects/MCHbtQVoQ2HCZWJoeSrzl9FQ/files/MCEJu8Y2hyDScV7ZDNnEvUAFDwjpqSh7JR4