### PR TITLE
fix(EditableLine): Call onChange on every change

### DIFF
--- a/packages/axiom-components/src/Editable/Editable.stories.js
+++ b/packages/axiom-components/src/Editable/Editable.stories.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import EditableTitle from "./EditableTitle";
 import EditableLine from "./EditableLine";
 import Heading from "../Typography/Heading";
@@ -9,13 +9,15 @@ export default {
 };
 
 export function Default() {
+  const [value, setValue] = useState("Editable text...");
+
   return (
     <EditableTitle>
       <Heading textSize="headline">
         <EditableLine
-          onChange={function () {}}
+          onChange={(event) => setValue(event.target.value)}
           placeholder="Editable text here"
-          value="Editable text..."
+          value={value}
         />
       </Heading>
     </EditableTitle>

--- a/packages/axiom-components/src/Editable/EditableLine.js
+++ b/packages/axiom-components/src/Editable/EditableLine.js
@@ -1,14 +1,15 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
+import classnames from "classnames";
 import "./EditableLine.css";
 
 export default class EditableLine extends Component {
   static propTypes = {
-    /** SKIP */
-    onBlur: PropTypes.func,
-    /** Callback with the value when the text has finished being edited */
+    /** Class name to be appended to the element */
+    className: PropTypes.string,
+    /** Handler for when the input field is changed */
     onChange: PropTypes.func.isRequired,
-    /** SKIP */
+    /** Handler for when a key is pressed int the input field */
     onKeyDown: PropTypes.func,
     /** Placeholder content to be displayed when there is no value */
     placeholder: PropTypes.string,
@@ -16,41 +17,12 @@ export default class EditableLine extends Component {
     value: PropTypes.string.isRequired,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: props.value,
-    };
-  }
-
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState({ value: nextProps.value });
-  }
-
-  handleOnBlur(event) {
-    if (this.state.value !== this.props.value) {
-      this.props.onChange(this.state.value);
-    }
-
-    if (this.props.onBlur) {
-      this.props.onBlur(event);
-    }
-  }
-
-  handleChange(event) {
-    this.setState({
-      value: event.target.value,
-    });
-  }
-
   handleOnKeyDown(event) {
     switch (event.key) {
       case "Enter":
+      case "Escape":
         event.preventDefault();
         this.input.blur();
-        break;
-      case "Escape":
-        this.setState({ value: this.props.value }, () => this.input.blur());
         break;
     }
 
@@ -60,20 +32,16 @@ export default class EditableLine extends Component {
   }
 
   render() {
-    const { value } = this.state;
-    const { placeholder, ...rest } = this.props;
+    const { className, placeholder, value, ...rest } = this.props;
 
     return (
-      <div className="ax-editable-line">
+      <div className={classnames("ax-editable-line", className)}>
         <input
           {...rest}
           className="ax-editable-line__input"
-          onBlur={(event) => this.handleOnBlur(event)}
-          onChange={(event) => this.handleChange(event)}
           onKeyDown={(event) => this.handleOnKeyDown(event)}
           placeholder={placeholder}
           ref={(el) => (this.input = el)}
-          value={value}
         />
 
         <div className="ax-editable-line__structure">


### PR DESCRIPTION
This PR changes the `EditableLine` from holding local state, to passing through the `onChange` handler and `value` property to the input.

**BREAKING CHANGE:** onChange of the `EditableLine` component is called on every change to the input now and receives the original event as an argument

---

Previously the `onChange` handler was only called on blur, if the value has changed. This caused an issue, where the value was reseted if the component was re-rendered while editing, before the blur event.

The issue can be produced in [this code sandbox](https://codesandbox.io/s/axiom-editable-line-issue-4j7fl).