### PR TITLE
feat(Icons): Add arrow left and right

### DIFF
--- a/packages/axiom-components/src/Icon/Icon.js
+++ b/packages/axiom-components/src/Icon/Icon.js
@@ -24,6 +24,8 @@ export default class Icon extends Component {
       "arrow-down",
       "arrow-down-left",
       "arrow-down-right",
+      "arrow-left",
+      "arrow-right",
       "arrow-up",
       "arrow-up-left",
       "arrow-up-right",

--- a/packages/axiom-components/src/Icon/iconNames.js
+++ b/packages/axiom-components/src/Icon/iconNames.js
@@ -6,6 +6,8 @@ const iconNames = [
   "arrow-down",
   "arrow-down-left",
   "arrow-down-right",
+  "arrow-left",
+  "arrow-right",
   "arrow-up",
   "arrow-up-left",
   "arrow-up-right",

--- a/packages/axiom-materials/src/icon_svgs/arrow-left.svg
+++ b/packages/axiom-materials/src/icon_svgs/arrow-left.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Arrow Left Icon</title>
+    <g id="Icon/Arrow-Left-Icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Arrow-Left-Icon" transform="translate(2.000000, 3.000000)" fill="#000000">
+            <polygon id="Icon" points="11.99209 3.99191 3.83408995 3.99191 6.37108995 1.45691 4.95708995 0.04291 0.00708995232 4.99191 4.95808995 9.94191 6.37108995 8.52791 3.83408995 5.99191 11.99209 5.99191"></polygon>
+        </g>
+    </g>
+</svg>

--- a/packages/axiom-materials/src/icon_svgs/arrow-right.svg
+++ b/packages/axiom-materials/src/icon_svgs/arrow-right.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Icon/Arrow Right Icon</title>
+    <g id="Icon/Arrow-Right-Icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Symbols---Icon---Arrow-Right" transform="translate(2.000000, 3.000000)" fill="#000000">
+            <polygon id="Icon" points="0.00738995232 5.99339 8.16538995 5.99339 5.62838995 8.52839 7.04238995 9.94239 11.99239 4.99339 7.04138995 0.04339 5.62838995 1.45739 8.16538995 3.99339 0.00738995232 3.99339"></polygon>
+        </g>
+    </g>
+</svg>

--- a/packages/axiom-materials/src/icons.js
+++ b/packages/axiom-materials/src/icons.js
@@ -6,6 +6,8 @@ export default {
   "arrow-down": require("./icon_svgs/arrow-down.svg"),
   "arrow-down-left": require("./icon_svgs/arrow-down-left.svg"),
   "arrow-down-right": require("./icon_svgs/arrow-down-right.svg"),
+  "arrow-left": require("./icon_svgs/arrow-left.svg"),
+  "arrow-right": require("./icon_svgs/arrow-right.svg"),
   "arrow-up": require("./icon_svgs/arrow-up.svg"),
   "arrow-up-left": require("./icon_svgs/arrow-up-left.svg"),
   "arrow-up-right": require("./icon_svgs/arrow-up-right.svg"),


### PR DESCRIPTION
We were missing the arrow left icon which is being used in a few upcoming designs. To complete the set, I also added the arrow right, which doesn't have an immediate use, but made sense to add at the same time. 

![image](https://user-images.githubusercontent.com/7532495/91471439-02e84d00-e88e-11ea-9c68-6c023624c827.png)
