### PR TITLE
fix: editable text sets value on input, adds minimum width for hit area

### DIFF
--- a/packages/axiom-components/src/Editable/Editable.stories.js
+++ b/packages/axiom-components/src/Editable/Editable.stories.js
@@ -9,14 +9,14 @@ export default {
 };
 
 export function Default() {
-  const [value, setValue] = useState("Editable text...");
+  const [value, setValue] = useState("Editable text");
 
   return (
     <EditableTitle>
       <Heading textSize="headline">
         <EditableLine
           onChange={(event) => setValue(event.target.value)}
-          placeholder="Editable text here"
+          placeholder="Edit…"
           value={value}
         />
       </Heading>

--- a/packages/axiom-components/src/Editable/EditableLine.css
+++ b/packages/axiom-components/src/Editable/EditableLine.css
@@ -6,6 +6,7 @@
 
 .ax-editable-line__structure {
   visibility: hidden;
+  min-width: 1em;
 }
 
 .ax-editable-line__input {

--- a/packages/axiom-components/src/Editable/EditableLine.css
+++ b/packages/axiom-components/src/Editable/EditableLine.css
@@ -5,8 +5,8 @@
 }
 
 .ax-editable-line__structure {
+  min-width: 1em; /* stylelint-disable-line unit-blacklist */
   visibility: hidden;
-  min-width: 1em;
 }
 
 .ax-editable-line__input {

--- a/packages/axiom-components/src/Editable/EditableLine.js
+++ b/packages/axiom-components/src/Editable/EditableLine.js
@@ -42,10 +42,11 @@ export default class EditableLine extends Component {
           onKeyDown={(event) => this.handleOnKeyDown(event)}
           placeholder={placeholder}
           ref={(el) => (this.input = el)}
+          value={value}
         />
 
         <div className="ax-editable-line__structure">
-          {value || placeholder || " "}
+          {value || placeholder || ""}
         </div>
       </div>
     );


### PR DESCRIPTION
#951 Added a change that removed `value` from the input, which seemed to break things for two reasons:

1. The value was ignored on the input
2. The `ax-editable-line__structure` element represented a different string, so the layout was broken

I've added this back in, and added a minimum width (of ~1 character), to make the hit-area more usable.

See sandbox for bug reproduction: https://codesandbox.io/s/axiom-boilerplate-forked-283h2?file=/src/components/App/index.js

It may not have been picked up because the storybook example had a similar string for both the value and placeholder, so the bug could have been missed in development.

cc @lpoulter @josa42 