### PR TITLE
refactor: 💡 Remove old context API from AlertDialog 

### DIFF
--- a/packages/axiom-components/src/AlertDialog/AlertDialog.js
+++ b/packages/axiom-components/src/AlertDialog/AlertDialog.js
@@ -1,45 +1,40 @@
 import PropTypes from "prop-types";
-import React, { Component } from "react";
+import React from "react";
 import Base from "../Base/Base";
 import Modal from "../Modal/Modal";
+import AlertDialogContext from "./AlertDialogContext";
 import "./AlertDialog.css";
 
-export default class AlertDialog extends Component {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    /** Visibility toggle for the AlertDialog */
-    isOpen: PropTypes.bool.isRequired,
-    /** Callback for closing the AlertDialog by clicking on the overlay */
-    onRequestClose: PropTypes.func.isRequired,
-    /** Toggle if the AlertDialog should be closed by pressing Esc */
-    shouldCloseOnEsc: PropTypes.bool,
-    /** Alert type */
-    type: PropTypes.oneOf(["error", "info", "success", "warning"]).isRequired,
-  };
-
-  static childContextTypes = {
-    onRequestClose: PropTypes.func.isRequired,
-    type: PropTypes.string.isRequired,
-  };
-
-  static defaultProps = {
-    type: "info",
-  };
-
-  getChildContext() {
-    return {
-      onRequestClose: this.props.onRequestClose,
-      type: this.props.type,
-    };
-  }
-
-  render() {
-    const { children, onRequestClose, ...rest } = this.props;
-
-    return (
-      <Modal {...rest} onOverlayClick={onRequestClose} overlayShade={null}>
-        <Base className="ax-alert-dialog">{children}</Base>
-      </Modal>
-    );
-  }
+export default function AlertDialog({
+  children,
+  onRequestClose,
+  type = "info",
+  ...rest
+}) {
+  return (
+    <Modal {...rest} onOverlayClick={onRequestClose} overlayShade={null}>
+      <Base className="ax-alert-dialog">
+        <AlertDialogContext.Provider
+          value={{
+            onRequestClose,
+            type,
+          }}
+        >
+          {children}
+        </AlertDialogContext.Provider>
+      </Base>
+    </Modal>
+  );
 }
+
+AlertDialog.propTypes = {
+  children: PropTypes.node.isRequired,
+  /** Visibility toggle for the AlertDialog */
+  isOpen: PropTypes.bool.isRequired,
+  /** Callback for closing the AlertDialog by clicking on the overlay */
+  onRequestClose: PropTypes.func.isRequired,
+  /** Toggle if the AlertDialog should be closed by pressing Esc */
+  shouldCloseOnEsc: PropTypes.bool,
+  /** Alert type */
+  type: PropTypes.oneOf(["error", "info", "success", "warning"]).isRequired,
+};

--- a/packages/axiom-components/src/AlertDialog/AlertDialogContext.js
+++ b/packages/axiom-components/src/AlertDialog/AlertDialogContext.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const AlertDialogContext = React.createContext();
+
+export default AlertDialogContext;

--- a/packages/axiom-components/src/AlertDialog/AlertDialogHeader.js
+++ b/packages/axiom-components/src/AlertDialog/AlertDialogHeader.js
@@ -1,34 +1,28 @@
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
-import React, { Component } from "react";
 import AlertBar from "../AlertBar/AlertBar";
 import Strong from "../Typography/Strong";
+import AlertDialogContext from "./AlertDialogContext";
 
-export default class AlertDialogHeader extends Component {
-  static propTypes = {
-    /** Header content inside the AlertDialog, a good place for a title */
-    children: PropTypes.node.isRequired,
-  };
+export default function AlertDialogHeader(props) {
+  const { onRequestClose, type } = useContext(AlertDialogContext);
 
-  static contextTypes = {
-    onRequestClose: PropTypes.func.isRequired,
-    type: PropTypes.string.isRequired,
-  };
+  const { children, ...rest } = props;
 
-  render() {
-    const { onRequestClose, type } = this.context;
-    const { children, ...rest } = this.props;
-
-    return (
-      <div className="ax-alert-dialog__header">
-        <AlertBar
-          {...rest}
-          onRemoveClick={onRequestClose}
-          size="medium"
-          type={type}
-        >
-          <Strong>{children}</Strong>
-        </AlertBar>
-      </div>
-    );
-  }
+  return (
+    <AlertBar
+      {...rest}
+      className="ax-alert-dialog__header"
+      onRemoveClick={onRequestClose}
+      size="medium"
+      type={type}
+    >
+      <Strong>{children}</Strong>
+    </AlertBar>
+  );
 }
+
+AlertDialogHeader.propTypes = {
+  /** Header content inside the AlertDialog, a good place for a title */
+  children: PropTypes.node.isRequired,
+};


### PR DESCRIPTION
This api is due to be removed and it's use will cause problems in
coming versions of React. Also converted to functional components to make use of hooks