### PR TITLE
refactor: 💡 Remove old context API from Button & ButtonGroup

### DIFF
--- a/packages/axiom-components/src/Button/Button.js
+++ b/packages/axiom-components/src/Button/Button.js
@@ -1,112 +1,88 @@
 import PropTypes from "prop-types";
-import React, { Component, Children, cloneElement } from "react";
+import React, { Children, cloneElement } from "react";
 import classnames from "classnames";
 import Base from "../Base/Base";
 import { isComponent } from "@brandwatch/axiom-utils";
 import { ButtonIconRef } from "./ButtonIcon";
 import "./Button.css";
 
-export default class Button extends Component {
-  static propTypes = {
-    /** Apply active styling */
-    active: PropTypes.bool,
-    /** Content inserted into the Button */
-    children: PropTypes.node.isRequired,
-    /** Class name to be appended to the element */
-    className: PropTypes.string,
-    /** Color of the button */
-    color: PropTypes.oneOf(["accent", "negative", "positive"]),
-    /** Disable interaction behaviour */
-    disabled: PropTypes.bool,
-    /**
-     * Controls the full width appearance of the badge either all of the time,
-     * with a value of `true` otherwise at one of the breakpoints specified.
-     */
-    full: PropTypes.oneOf([true, "small", "medium", "large"]),
-    /** Forces button to loose it's rounded styling on the left side */
-    joinedLeft: PropTypes.bool,
-    /** Forces button to loose it's rounded styling on the right side */
-    joinedRight: PropTypes.bool,
-    /** Shape of the button */
-    shape: PropTypes.oneOf(["circle", "rectangle", "stadium"]),
-    /** Size of standard shape */
-    size: PropTypes.oneOf(["small", "medium", "large", "huge"]),
-    /** variant of the Button, which affects its coloring and sizing */
-    variant: PropTypes.oneOf([
-      "primary",
-      "secondary",
-      "tertiary",
-      "quaternary",
-    ]),
-  };
+export default function Button({
+  active,
+  children,
+  className,
+  color = "accent",
+  disabled,
+  joined,
+  joinedLeft,
+  joinedRight,
+  shape = "rectangle",
+  variant = "primary",
+  size = "medium",
+  full,
+  ...rest
+}) {
+  const childrenArray = Children.toArray(children);
+  const iconOnly =
+    childrenArray.length === 1 && isComponent(childrenArray[0], ButtonIconRef);
+  const classes = classnames(
+    "ax-button",
+    `ax-button--${color}`,
+    `ax-button--${variant}`,
+    `ax-button--${shape}-${size}`,
+    {
+      "ax-button--active": active,
+      "ax-button--joined": joined,
+      "ax-button--joined-left": joinedLeft,
+      "ax-button--joined-right": joinedRight,
+      "ax-button--icon-only": shape === "rectangle" && iconOnly,
+      "ax-button--full": full === true,
+      [`ax-button--full--${full}`]: typeof full === "string",
+    },
+    className
+  );
 
-  static contextTypes = {
-    joined: PropTypes.bool,
-  };
+  const mappedChildren = childrenArray.map((child, index, array) =>
+    !isComponent(child, ButtonIconRef)
+      ? child
+      : cloneElement(child, {
+          isEnd: index === array.length - 1,
+          isStart: index === 0,
+        })
+  );
 
-  static defaultProps = {
-    color: "accent",
-    shape: "rectangle",
-    size: "medium",
-    variant: "primary",
-  };
-
-  render() {
-    const { joined } = this.context;
-    const {
-      active,
-      children,
-      className,
-      color,
-      disabled,
-      joinedLeft,
-      joinedRight,
-      shape,
-      variant,
-      size,
-      full,
-      ...rest
-    } = this.props;
-
-    const childrenArray = Children.toArray(children);
-    const iconOnly =
-      childrenArray.length === 1 &&
-      isComponent(childrenArray[0], ButtonIconRef);
-    const classes = classnames(
-      "ax-button",
-      `ax-button--${color}`,
-      `ax-button--${variant}`,
-      `ax-button--${shape}-${size}`,
-      {
-        "ax-button--active": active,
-        "ax-button--joined": joined,
-        "ax-button--joined-left": joinedLeft,
-        "ax-button--joined-right": joinedRight,
-        "ax-button--icon-only": shape === "rectangle" && iconOnly,
-        "ax-button--full": full === true,
-        [`ax-button--full--${full}`]: typeof full === "string",
-      },
-      className
-    );
-
-    const mappedChildren = childrenArray.map((child, index, array) =>
-      !isComponent(child, ButtonIconRef)
-        ? child
-        : cloneElement(child, {
-            isEnd: index === array.length - 1,
-            isStart: index === 0,
-          })
-    );
-
-    return (
-      <Base
-        Component="button"
-        {...rest}
-        className={classes}
-        disabled={disabled}
-      >
-        {mappedChildren}
-      </Base>
-    );
-  }
+  return (
+    <Base Component="button" {...rest} className={classes} disabled={disabled}>
+      {mappedChildren}
+    </Base>
+  );
 }
+
+Button.propTypes = {
+  /** Apply active styling */
+  active: PropTypes.bool,
+  /** Content inserted into the Button */
+  children: PropTypes.node.isRequired,
+  /** Class name to be appended to the element */
+  className: PropTypes.string,
+  /** Color of the button */
+  color: PropTypes.oneOf(["accent", "negative", "positive"]),
+  /** Disable interaction behaviour */
+  disabled: PropTypes.bool,
+  /**
+   * Controls the full width appearance of the badge either all of the time,
+   * with a value of `true` otherwise at one of the breakpoints specified.
+   */
+  full: PropTypes.oneOf([true, "small", "medium", "large"]),
+  /** SKIP */
+  joined: PropTypes.bool,
+  /** Forces button to loose it's rounded styling on the left side */
+  joinedLeft: PropTypes.bool,
+  /** Forces button to loose it's rounded styling on the right side */
+  joinedRight: PropTypes.bool,
+  /** Shape of the button */
+  shape: PropTypes.oneOf(["circle", "rectangle", "stadium"]),
+  /** Size of standard shape */
+  size: PropTypes.oneOf(["small", "medium", "large", "huge"]),
+  /** variant of the Button, which affects its coloring and sizing */
+  variant: PropTypes.oneOf(["primary", "secondary", "tertiary", "quaternary"]),
+};

--- a/packages/axiom-components/src/Button/ButtonGroup.js
+++ b/packages/axiom-components/src/Button/ButtonGroup.js
@@ -1,39 +1,34 @@
 import PropTypes from "prop-types";
-import React, { Component } from "react";
+import React from "react";
 import Base from "../Base/Base";
 import InlineGroup from "../InlineGroup/InlineGroup";
 
-export default class ButtonGroup extends Component {
-  static propTypes = {
-    /** Content inserted into the group, ideally Buttons */
-    children: PropTypes.node.isRequired,
-    /** Whether the child Buttons should be joined */
-    joined: PropTypes.bool,
-  };
+export default function ButtonGroup({ children, joined, ...rest }) {
+  const mappedChildren = React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child, {
+        joined,
+      });
+    }
+    return child;
+  });
 
-  static childContextTypes = {
-    joined: PropTypes.bool,
-  };
-
-  getChildContext() {
-    return {
-      joined: this.props.joined,
-    };
-  }
-
-  render() {
-    const { children, joined, ...rest } = this.props;
-
-    return (
-      <Base
-        space="x6"
-        {...rest}
-        Component={joined ? "div" : InlineGroup}
-        className="ax-button-group"
-        textBreak={joined ? "none" : null}
-      >
-        {children}
-      </Base>
-    );
-  }
+  return (
+    <Base
+      space="x6"
+      {...rest}
+      Component={joined ? "div" : InlineGroup}
+      className="ax-button-group"
+      textBreak={joined ? "none" : null}
+    >
+      {mappedChildren}
+    </Base>
+  );
 }
+
+ButtonGroup.propTypes = {
+  /** Content inserted into the group, ideally Buttons */
+  children: PropTypes.node.isRequired,
+  /** Whether the child Buttons should be joined */
+  joined: PropTypes.bool,
+};

--- a/packages/axiom-components/src/Progress/ProgressButton.js
+++ b/packages/axiom-components/src/Progress/ProgressButton.js
@@ -33,8 +33,8 @@ export default class ProgressButton extends Component {
     const {
       children,
       isInProgress,
-      size = Button.defaultProps.size,
-      variant = Button.defaultProps.variant,
+      size = "medium",
+      variant = "primary",
       ...rest
     } = this.props;
 


### PR DESCRIPTION
No need to replace just pass 'joined' prop to children of ButtonGroup