### PR TITLE
fix(TextInput): Use error colors for invalid states, even if focused

### DIFF
--- a/packages/axiom-components/src/Form/TextInput.css
+++ b/packages/axiom-components/src/Form/TextInput.css
@@ -103,7 +103,7 @@
   border-color: rgba(var(--rgb-ui-error), var(--opacity-input-border--valid));
 }
 
-.ax-input__icon-container--invalid:not(.ax-input__icon-container--focused) {
+.ax-input__icon-container--invalid {
   border-color: rgba(var(--rgb-ui-error), var(--opacity-input-border--invalid));
   color: var(--color-ui-error);
 


### PR DESCRIPTION
Currently the `TextInput` which has `invalid={true}` and is focused, shows a blue border and normal text color.

![textinput--pre](https://user-images.githubusercontent.com/423234/92908978-00a5f700-f427-11ea-9334-b3f21baa5708.gif)

This PR makes sure the error color is used, even if the input is focused.

![textinput-post](https://user-images.githubusercontent.com/423234/92909256-41057500-f427-11ea-869a-4fbbb92f6331.gif)
