### PR TITLE
fix: 🐛 Ensure onRequestClose is passed to dialog header

### DIFF
--- a/packages/axiom-components/src/Dialog/Dialog.js
+++ b/packages/axiom-components/src/Dialog/Dialog.js
@@ -3,6 +3,7 @@ import React from "react";
 import classnames from "classnames";
 import Base from "../Base/Base";
 import Modal from "../Modal/Modal";
+import DialogContext from "./DialogContext";
 import "./Dialog.css";
 
 export default function Dialog({
@@ -29,17 +30,6 @@ export default function Dialog({
 
   const modalPadding = size === "fullscreen" ? "x0" : padding;
 
-  const mappedChildren = React.Children.map(children, (child) => {
-    if (React.isValidElement(child)) {
-      if (child.type.displayName === "DialogHeader") {
-        return React.cloneElement(child, {
-          onRequestClose,
-        });
-      }
-    }
-    return child;
-  });
-
   return (
     <Modal
       {...rest}
@@ -50,7 +40,9 @@ export default function Dialog({
       padding={modalPadding}
     >
       <Base className={classes} style={{ width }} theme={theme}>
-        {mappedChildren}
+        <DialogContext.Provider value={{ onRequestClose }}>
+          {children}
+        </DialogContext.Provider>
       </Base>
     </Modal>
   );

--- a/packages/axiom-components/src/Dialog/DialogContext.js
+++ b/packages/axiom-components/src/Dialog/DialogContext.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export default React.createContext();

--- a/packages/axiom-components/src/Dialog/DialogHeader.js
+++ b/packages/axiom-components/src/Dialog/DialogHeader.js
@@ -1,15 +1,16 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useContext } from "react";
 import classnames from "classnames";
 import Base from "../Base/Base";
 import Grid from "../Grid/Grid";
 import GridCell from "../Grid/GridCell";
 import Icon from "../Icon/Icon";
 import Link from "../Typography/Link";
+import DialogContext from "./DialogContext";
 
 export default function DialogHeader(props) {
-  const { children, className, onRequestClose, ...rest } = props;
-
+  const { children, className, ...rest } = props;
+  const { onRequestClose } = useContext(DialogContext);
   const classes = classnames("ax-dialog__header", className);
 
   return (
@@ -32,6 +33,4 @@ DialogHeader.propTypes = {
   children: PropTypes.node,
   /** Class name to be appended to the element */
   className: PropTypes.string,
-  /** SKIP */
-  onRequestClose: PropTypes.func,
 };


### PR DESCRIPTION
This PR superseeds #965, thanks to @josa42 for raising this bug and putting in a fix. 

The previous method of using DisplayName to clone in onRequest close to
the dialog header didn't work in production because displayName was
getting removed in the build process, not sure by what. Using context
should be more reliable and also have the benefit of allowing dialog
header to be wrapped in other elements. A trade of here is Dialogheader 
cannot be used outside of Dialog but I don't see this a problem in this case.