### PR TITLE
feat: 🎸 Pass Popper Modifiers to Position

### DIFF
--- a/packages/axiom-components/src/Position/Position.js
+++ b/packages/axiom-components/src/Position/Position.js
@@ -75,6 +75,10 @@ export default class Position extends Component {
     reference: PropTypes.object,
     /** Toggle that allows the arrow of the Context component to be hidden */
     showArrow: PropTypes.bool,
+    /**
+     * PopperJs Modifiers see https://popper.js.org/docs/v2/modifiers/
+     */
+    popperModifiers: PropTypes.array,
   };
 
   static defaultProps = {
@@ -84,6 +88,7 @@ export default class Position extends Component {
     offset: "middle",
     position: "top",
     showArrow: false,
+    popperModifiers: [],
   };
 
   constructor(props) {
@@ -103,7 +108,6 @@ export default class Position extends Component {
 
   componentDidUpdate() {
     const { enabled, isVisible, position, offset } = this.props;
-
     if (enabled && isVisible) {
       if (!this._popper) {
         this._popper = this.createPopper();
@@ -122,7 +126,13 @@ export default class Position extends Component {
   }
 
   createPopper() {
-    const { boundariesElement, flip, showArrow, reference } = this.props;
+    const {
+      boundariesElement,
+      flip,
+      showArrow,
+      reference,
+      popperModifiers,
+    } = this.props;
     const { placement } = this.state;
 
     const modifiers = [
@@ -163,6 +173,7 @@ export default class Position extends Component {
           boundariesElement,
         },
       },
+      ...popperModifiers,
     ];
 
     return createPopper(reference || this._target, this._content, {

--- a/packages/axiom-components/src/Position/Position.stories.css
+++ b/packages/axiom-components/src/Position/Position.stories.css
@@ -1,0 +1,19 @@
+.call-to-action-tooltip__content {
+  display: flex;
+}
+
+.call-to-action-tooltip__content__image-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 8.1875rem;
+  background-color: var(--color-theme-day-background--shade-2);
+  color: var(--color-theme-day-text--subtle);
+}
+
+.call-to-action-tooltip__content__text-container {
+  flex: 4;
+  padding: var(--spacing-grid-size--x4);
+  padding-right: var(--spacing-grid-size--x8);
+  padding-left: var(--spacing-grid-size--x8);
+}

--- a/packages/axiom-components/src/Position/Position.stories.js
+++ b/packages/axiom-components/src/Position/Position.stories.js
@@ -3,10 +3,19 @@ import Position from "./Position";
 import PositionTarget from "./PositionTarget";
 import PositionSource from "./PositionSource";
 import Context from "../Context/Context";
+import ContextContent from "../Context/ContextContent";
 import ContextMenu from "../Context/ContextMenu";
 import Icon from "../Icon/Icon";
+import Button from "../Button/Button";
+import IconButton from "../Icon/IconButton";
+import ButtonGroup from "../Button/ButtonGroup";
+import ButtonIcon from "../Button/ButtonIcon";
 import Heading from "../Typography/Heading";
+import Paragraph from "../Typography/Paragraph";
+import Strong from "../Typography/Strong";
 import Toggle from "../Toggle/Toggle";
+
+import "./Position.stories.css";
 
 export default {
   title: "Position",
@@ -18,7 +27,7 @@ export function Default(props) {
   const [isVisible, setIsVisible] = useState(false);
 
   return (
-    <div>
+    <>
       <Toggle onToggle={() => setIsVisible((v) => !v)}>Show</Toggle>
       <Position isVisible={isVisible} position="bottom" showArrow {...props}>
         <PositionTarget>
@@ -39,6 +48,82 @@ export function Default(props) {
           </Context>
         </PositionSource>
       </Position>
-    </div>
+    </>
   );
 }
+
+export function PassModifiersToPopperJs(props) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <>
+      <Toggle onToggle={() => setIsVisible((v) => !v)}>Show</Toggle>
+      <Position isVisible={isVisible} position="bottom" showArrow {...props}>
+        <PositionTarget>
+          <IconButton name="question-mark" size="small" />
+        </PositionTarget>
+
+        <PositionSource>
+          <Context width="496px">
+            <ContextContent padding="none">
+              <div className="call-to-action-tooltip__content">
+                <div className="call-to-action-tooltip__content__image-container">
+                  <Icon name="magnify-glass" size="3rem" textcolor="subtle" />
+                </div>
+                <div className="call-to-action-tooltip__content__text-container">
+                  <Heading textSize="headtitle">
+                    <Strong>New!</Strong> Brandwatch Feature
+                  </Heading>
+                  <Paragraph>
+                    Brandwatch Feature is an instant engine. It collects data on
+                    any topic.
+                  </Paragraph>
+                  <Paragraph>
+                    Using powerful AI, Brandwatch Feature identifies the data
+                    you are looking for.
+                  </Paragraph>
+                  <Paragraph>
+                    And there’s no need for writing long, complex boolean. Just
+                    start typing.
+                  </Paragraph>
+                  <ButtonGroup>
+                    <Button>Got it</Button>
+                    <Button variant="tertiary">
+                      Find out more <ButtonIcon name="open" />
+                    </Button>
+                  </ButtonGroup>
+                </div>
+              </div>
+            </ContextContent>
+          </Context>
+        </PositionSource>
+      </Position>
+    </>
+  );
+}
+
+PassModifiersToPopperJs.args = {
+  popperModifiers: [
+    {
+      name: "preventOverflow",
+      options: {
+        padding: 15,
+      },
+    },
+    {
+      name: "offset",
+      options: {
+        offset: [0, 60],
+      },
+    },
+  ],
+};
+
+PassModifiersToPopperJs.parameters = {
+  docs: {
+    description: {
+      story:
+        "You can pass an array of Popper modifiers to Position which will be based to PopperJs see the [Popper docs](https://popper.js.org/docs/v2/modifiers/) for more details. Note: If you pass a modifier that Axiom is already setting you will overwrite Axiom's modifiers.",
+    },
+  },
+};

--- a/packages/axiom-components/src/Slider/__snapshots__/Handle.test.js.snap
+++ b/packages/axiom-components/src/Slider/__snapshots__/Handle.test.js.snap
@@ -7,6 +7,7 @@ exports[`Handle renders with custom props 1`] = `
   flip="clockwise"
   isVisible={false}
   offset="middle"
+  popperModifiers={Array []}
   position="top"
   showArrow={true}
 >
@@ -44,6 +45,7 @@ exports[`Handle renders with defaultProps 1`] = `
   flip="clockwise"
   isVisible={true}
   offset="middle"
+  popperModifiers={Array []}
   position="top"
   showArrow={true}
 >


### PR DESCRIPTION

This will allow setting and overriding of Popper modifiers via the Axiom Position component. Other components that spread props to Position such as Dropdown and Tooltip will also support this feature.

Closes #985  