### PR TITLE
fix: Increase specificity for table header wrapping

### DIFF
--- a/packages/axiom-components/src/Table/Table.css
+++ b/packages/axiom-components/src/Table/Table.css
@@ -160,7 +160,7 @@
 }
 
 /* stylelint-disable value-no-vendor-prefix, property-no-vendor-prefix */
-.ax-table__header-tooltip--wrap {
+.ax-table__header-tooltip--wrap.ax-table__header-tooltip--wrap {
   display: -webkit-box;
   white-space: normal;
   -webkit-line-clamp: 2;


### PR DESCRIPTION
In #923 a change was added to enable multi-line table header cells. I came across an issue where this didn't work. After some digging it turned out CSS for `.ax-text--ellipsis` was applied *after* the CSS for `TableHeader` was applied. This caused the CSS for `ax-table__header-tooltip--wrap` to be overwritten: More specifically the `white-space: nowrap;` was applied.

https://github.com/BrandwatchLtd/axiom-react/blob/4ae7091507289fa76ebf1dc075ad7a8c7915c806/packages/axiom-components/src/Typography/Text.css#L73-L78

https://github.com/BrandwatchLtd/axiom-react/blob/5c6de061f22bee6f27fecd8e912a1a27dedfca9e/packages/axiom-components/src/Table/Table.css#L163-L168

The easiest fix seems to be to increase the CSS selector specificity to give it more weight so the order of import doesn't matter. Another solution would be to add `!important;` to the `white-space: normal;` in `ax-table__header-tooltip--wrap`.