### PR TITLE
docs: ✏️ Correctly ignore probs with JSdocs and storybook

### DIFF
--- a/packages/axiom-charts/src/DataPoint/DataPoint.js
+++ b/packages/axiom-charts/src/DataPoint/DataPoint.js
@@ -47,7 +47,7 @@ export default class DataPoint extends Component {
       "ui-warning",
       "ui-error",
     ]).isRequired,
-    /** SKIP */
+    /** @ignore */
     r: PropTypes.number,
     /** Style of the DataPoint */
     style: PropTypes.oneOf(["hollow", "solid"]),

--- a/packages/axiom-charts/src/Line/LinePoint.js
+++ b/packages/axiom-charts/src/Line/LinePoint.js
@@ -68,17 +68,17 @@ export default class LinePoint extends Component {
     onDropdownClose: PropTypes.func,
     /** Call back for when a given Context component opens */
     onDropdownOpen: PropTypes.func,
-    /** SKIP */
+    /** @ignore */
     onMouseEnter: PropTypes.func,
     /** Size of the DataPoint */
     size: PropTypes.string.isRequired,
     /** Style of the DataPoint */
     style: PropTypes.oneOf(["hollow", "solid"]),
-    /** SKIP */
+    /** @ignore */
     value: PropTypes.number,
-    /** SKIP */
+    /** @ignore */
     x: PropTypes.number,
-    /** SKIP */
+    /** @ignore */
     y: PropTypes.number,
   };
 

--- a/packages/axiom-components/src/Button/Button.js
+++ b/packages/axiom-components/src/Button/Button.js
@@ -73,7 +73,7 @@ Button.propTypes = {
    * with a value of `true` otherwise at one of the breakpoints specified.
    */
   full: PropTypes.oneOf([true, "small", "medium", "large"]),
-  /** SKIP */
+  /** @ignore */
   joined: PropTypes.bool,
   /** Forces button to loose it's rounded styling on the left side */
   joinedLeft: PropTypes.bool,

--- a/packages/axiom-components/src/Button/ButtonIcon.js
+++ b/packages/axiom-components/src/Button/ButtonIcon.js
@@ -10,9 +10,9 @@ export default class ButtonIcon extends Component {
   static propTypes = {
     /** Color of the Icon */
     color: PropTypes.string,
-    /** SKIP */
+    /** @ignore */
     isEnd: PropTypes.bool,
-    /** SKIP */
+    /** @ignore */
     isStart: PropTypes.bool,
     /** Name of the Icon */
     name: PropTypes.string.isRequired,

--- a/packages/axiom-components/src/Card/Card.js
+++ b/packages/axiom-components/src/Card/Card.js
@@ -50,7 +50,7 @@ Card.propTypes = {
   border: PropTypes.bool,
   /** Applies border radius */
   borderRadius: PropTypes.oneOf(["small", "large"]),
-  /** SKIP */
+  /** @ignore */
   cardListStyle: PropTypes.oneOf(["divided", "seamless", "separate"]),
   /** Content to be inserted inside the Card */
   children: PropTypes.node.isRequired,

--- a/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
+++ b/packages/axiom-components/src/Dropdown/DropdownMenuItem.js
@@ -6,7 +6,7 @@ import DropdownReactContext from "./DropdownReactContext";
 
 export default class DropdownMenuItem extends Component {
   static propTypes = {
-    /** SKIP */
+    /** @ignore */
     children: PropTypes.node,
     /** Disabled interactions and applies styling */
     disabled: PropTypes.bool,

--- a/packages/axiom-components/src/Form/TextInput.js
+++ b/packages/axiom-components/src/Form/TextInput.js
@@ -65,7 +65,7 @@ export default class TextInput extends Component {
     required: PropTypes.bool,
     /** Size of the input field */
     size: PropTypes.oneOf(["small", "medium", "large"]),
-    /** SKIP */
+    /** @ignore */
     space: PropTypes.string,
     /** Visual style variations of the input field */
     style: PropTypes.oneOf(["overlay"]),

--- a/packages/axiom-components/src/Icon/Icon.js
+++ b/packages/axiom-components/src/Icon/Icon.js
@@ -8,7 +8,7 @@ import "./Icon.css";
 
 export default class Icon extends Component {
   static propTypes = {
-    /** SKIP */
+    /** @ignore */
     className: PropTypes.string,
     /**
      * Inline styling that allows the Icon to placed next to other inline

--- a/packages/axiom-components/src/Image/Image.js
+++ b/packages/axiom-components/src/Image/Image.js
@@ -17,9 +17,9 @@ export default class Image extends Component {
     height: PropTypes.string,
     /** @type {[type]} [description] */
     maxWidth: PropTypes.string,
-    /** SKIP */
+    /** @ignore */
     onError: PropTypes.func,
-    /** SKIP */
+    /** @ignore */
     onLoad: PropTypes.func,
     /** Shape of the image */
     shape: PropTypes.oneOf(["circle", "rounded", "square"]),

--- a/packages/axiom-components/src/Label/LabelIcon.js
+++ b/packages/axiom-components/src/Label/LabelIcon.js
@@ -9,11 +9,11 @@ export const LabelIconRef = "LabelIcon";
 
 export default class LabelIcon extends Component {
   static propTypes = {
-    /** SKIP */
+    /** @ignore */
     color: PropTypes.string,
-    /** SKIP */
+    /** @ignore */
     isEnd: PropTypes.bool,
-    /** SKIP */
+    /** @ignore */
     isStart: PropTypes.bool,
     /** Name of the icon. See <Icon>. */
     name: PropTypes.string.isRequired,

--- a/packages/axiom-components/src/Reveal/Reveal.js
+++ b/packages/axiom-components/src/Reveal/Reveal.js
@@ -11,7 +11,7 @@ export default class Reveal extends Component {
     children: PropTypes.node.isRequired,
     /** Removes children from the reveal container when it is collapsed */
     removeChildren: PropTypes.bool,
-    /** SKIP */
+    /** @ignore */
     space: PropTypes.string,
     /** Revealed status, true will expand out the content, false will collapse it. */
     visible: PropTypes.bool.isRequired,

--- a/packages/axiom-components/src/Select/SelectInput.js
+++ b/packages/axiom-components/src/Select/SelectInput.js
@@ -7,7 +7,7 @@ import DropdownReactContext from "../Dropdown/DropdownReactContext";
 export default class SelectInput extends Component {
   static propTypes = {
     children: PropTypes.node,
-    /** SKIP */
+    /** @ignore */
     onFocus: PropTypes.func,
   };
 

--- a/packages/axiom-components/src/Tooltip/Tooltip.js
+++ b/packages/axiom-components/src/Tooltip/Tooltip.js
@@ -77,7 +77,7 @@ Tooltip.propTypes = {
    * Adds control to enable or disable showing the TooltipSource
    */
   enabled: PropTypes.bool,
-  /** SKIP */
+  /** @ignore */
   onClick: PropTypes.func,
   /**
    * Controls the starting position around TooltipTarget in which the

--- a/packages/axiom-components/src/Tooltip/TooltipTarget.js
+++ b/packages/axiom-components/src/Tooltip/TooltipTarget.js
@@ -9,10 +9,10 @@ export default class TooltipTarget extends Component {
   static propTypes = {
     children: PropTypes.node,
     delay: PropTypes.bool,
-    /** SKIP */
+    /** @ignore */
     hideTooltip: PropTypes.func,
     onClick: PropTypes.func,
-    /** SKIP */
+    /** @ignore */
     showTooltip: PropTypes.func,
   };
 


### PR DESCRIPTION
These properties are only internal for internal use and should not be documented.
Skip was left over from the old docs and did not work with storybook.

Before.
<img width="1049" alt="Screenshot 2020-10-16 at 08 43 52" src="https://user-images.githubusercontent.com/3940567/96227237-c252a900-0f8b-11eb-9a60-6a8bc32a09d5.png">

After
<img width="1052" alt="Screenshot 2020-10-16 at 08 46 54" src="https://user-images.githubusercontent.com/3940567/96227541-2aa18a80-0f8c-11eb-9758-896b95f9d04b.png">
