### PR TITLE
fix: 🐛 Update unselected tab text color to be subtle

### DIFF
--- a/packages/axiom-components/src/Table/Table.stories.js
+++ b/packages/axiom-components/src/Table/Table.stories.js
@@ -23,11 +23,12 @@ export function Default() {
     <Table>
       <TableHeader>
         <TableHeaderLabel sortDirection="ascending">Column A</TableHeaderLabel>
-        <TableHeaderLabel>Column B</TableHeaderLabel>
+        <TableHeaderLabel>lower case</TableHeaderLabel>
         <TableHeaderLabel wrap={true}>
           Super long Column C label with wrapping Lorem ipsum
         </TableHeaderLabel>
-        <TableHeaderLabel>Column D</TableHeaderLabel>
+        <TableHeaderLabel>CAPS LOCK</TableHeaderLabel>
+        <TableHeaderLabel>Title Case Please</TableHeaderLabel>
       </TableHeader>
       <TableBody>
         <TableRow>

--- a/packages/axiom-components/src/Tabset/Tabset.css
+++ b/packages/axiom-components/src/Tabset/Tabset.css
@@ -51,7 +51,7 @@
   outline: 0;
   border: 0;
   background: none;
-  color: inherit;
+  color: var(--color-theme-text--subtle);
   text-transform: capitalize;
   line-height: var(--component-line-height);
   transition-property: color;
@@ -67,6 +67,10 @@
     color: var(--color-theme-text--disabled);
     cursor: default;
   }
+}
+
+.ax-tabset__list-item--active .ax-tabset__button {
+  color: var(--color-ui-accent--active);
 }
 
 .ax-tabset__list--medium .ax-tabset__button {

--- a/packages/axiom-components/src/Tabset/Tabset.stories.js
+++ b/packages/axiom-components/src/Tabset/Tabset.stories.js
@@ -25,7 +25,7 @@ export function Default({ size, space, activeTabIndex }) {
         velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
         Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
       </Tab>
-      <Tab title="Tab 3">
+      <Tab title="disabled" disabled>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
         libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
         tristique ipsum non vehicula. In eget libero lobortis, sollicitudin


### PR DESCRIPTION
To bring inline with original designs