### PR TITLE
fix: 🐛 Only captalise the first letter of the first word. 

### DIFF
--- a/packages/axiom-components/src/Tabset/Tab.stories.js
+++ b/packages/axiom-components/src/Tabset/Tab.stories.js
@@ -10,21 +10,21 @@ export default {
 export function Default(props) {
   return (
     <Tabset>
-      <Tab title="Tab 1" {...props}>
+      <Tab title="brandwatch Alerts" {...props}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
         libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
         tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
         velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
         Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
       </Tab>
-      <Tab title="Tab 2" {...props}>
+      <Tab title="twitter" {...props}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
         libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
         tristique ipsum non vehicula. In eget libero lobortis, sollicitudin
         velit nec, accumsan dolor. Morbi in finibus mauris, id pretium ipsum.
         Sed quis massa tempus nunc molestie ultrices sit amet vel urna.
       </Tab>
-      <Tab title="Tab 3" {...props}>
+      <Tab title={<span>facebook channel</span>} {...props}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla mauris
         libero, suscipit eu dignissim eu, consectetur in mauris. Donec semper
         tristique ipsum non vehicula. In eget libero lobortis, sollicitudin

--- a/packages/axiom-components/src/Tabset/Tabset.css
+++ b/packages/axiom-components/src/Tabset/Tabset.css
@@ -52,7 +52,6 @@
   border: 0;
   background: none;
   color: var(--color-theme-text--subtle);
-  text-transform: capitalize;
   line-height: var(--component-line-height);
   transition-property: color;
   transition-duration: var(--transition-time-base);
@@ -66,6 +65,10 @@
   &:disabled {
     color: var(--color-theme-text--disabled);
     cursor: default;
+  }
+
+  &::first-letter {
+    text-transform: capitalize;
   }
 }
 

--- a/packages/axiom-components/src/Tabset/Tabset.js
+++ b/packages/axiom-components/src/Tabset/Tabset.js
@@ -6,6 +6,9 @@ import Base from "../Base/Base";
 import Tabs from "./Tabs";
 import { TabRef } from "./Tab";
 
+/**
+ * Tabsets are useful to alternate between related views within the same context.
+ */
 export default class Tabset extends Component {
   static propTypes = {
     /**


### PR DESCRIPTION
Updated to match our [new copy guidelines](https://gallery.io/projects/MCHbtQVoQ2HCZWJoeSrzl9FQ/files/MCEJu8Y2hyDScS4WA3eOZHqwVJrDBGgTc1w).

Before
<img width="143" alt="Screenshot 2020-12-17 at 13 27 25" src="https://user-images.githubusercontent.com/3940567/102493829-a773e200-406b-11eb-8154-0ab161c46e39.png">

After

<img width="155" alt="Screenshot 2020-12-17 at 13 27 30" src="https://user-images.githubusercontent.com/3940567/102493879-bf4b6600-406b-11eb-9bef-1e1e2c8d6abf.png">

