### PR TITLE
CP-563 Add Tooltip & HC link in the query builder

### DIFF
--- a/packages/axiom-components/src/UsageHint/UsageHint.js
+++ b/packages/axiom-components/src/UsageHint/UsageHint.js
@@ -15,31 +15,36 @@ import Link from "../Typography/Link";
 export default class UsageHint extends PureComponent {
   static propTypes = {
     children: PropTypes.node,
+    iconName: PropTypes.oneOf(["information-circle", "question-mark-circle"]),
+    inline: PropTypes.bool,
+    /** Padding size applied to the content area */
+    padding: PropTypes.oneOf(["none", "small", "medium", "large"]),
     position: PropTypes.oneOf(["top", "bottom", "left", "right"]),
     showArrow: PropTypes.bool,
-    inline: PropTypes.bool,
     /** Total width of the usageHint dropdown context */
     width: PropTypes.string,
   };
 
   static defaultProps = {
-    showArrow: true,
     inline: false,
+    iconName: "question-mark-circle",
+    padding: "large",
+    showArrow: true,
   };
 
   render() {
-    const { children, inline, width, ...rest } = this.props;
+    const { children, inline, iconName, padding, width, ...rest } = this.props;
 
     return (
       <Dropdown {...rest} showArrow>
         <DropdownTarget>
           <Link style="subtle">
-            <Icon inline={inline} name="question-mark-circle" size="1rem" />
+            <Icon inline={inline} name={iconName} size="1rem" />
           </Link>
         </DropdownTarget>
         <DropdownSource>
           <DropdownContext width={width}>
-            <DropdownContent>{children}</DropdownContent>
+            <DropdownContent padding={padding}>{children}</DropdownContent>
           </DropdownContext>
         </DropdownSource>
       </Dropdown>


### PR DESCRIPTION
This PR does two things: 
- adds an information circle icon as a possible icon for UsageHint
- passes padding to `DropdownContent`, which enables us to have a smaller padding, the current default is `large`, which is imo too big and I'd like the option to change it flexibly

If you have a reason as to why the `information-circle` isn't suitable for a `UsageHint`, I'm fine with it. But I would really like if we could have more flexible paddings on `UsageHint`, since the logic is essentially there, and if the `UsageHint` does not contain a lot of text it looks weird.

![image](https://user-images.githubusercontent.com/30578445/107982483-6bee8900-6fc4-11eb-9eeb-b7585abf7f6c.png)
