### PR TITLE
feat: default duration picker selected unit to days if valid

### DIFF
--- a/packages/axiom-components/src/DurationPicker/DurationPicker.js
+++ b/packages/axiom-components/src/DurationPicker/DurationPicker.js
@@ -154,7 +154,9 @@ export default class DurationPicker extends Component {
     );
 
     const {
-      selectedUnit = filteredTimeUnits[0],
+      selectedUnit = filteredTimeUnits.includes("days")
+        ? "days"
+        : filteredTimeUnits[0],
       selectedValue = "",
     } = this.state;
 


### PR DESCRIPTION
if days is not excludes then the selected unit by default will be days
days is often the most supported unit of time. This is particularly
useful in Vizia where we want to update a number of components at once
but not all support mins/hours etc. only day. We do not want to exclude
these other options as they are still valid for a subset of the components

We have the case at the moment in Deck Level Filters that I want to have no numeric value, but default the time unit to days.
I want this because the default numeric value might be different than the current values of some of the components - which would lead to an update without the user intending to do so.
I want to a a nicety have the default time unit to be days as this is the most supported time unit across our components in Vizia.
All of this is likely to be updated soon anyway with @stefanpearson's new date/duration picker.
This change shouldn't affect anyone who passes in a valid ISO duration value by default.