### PR TITLE
fix: default selected duration unit when empty selected value

### DIFF
--- a/packages/axiom-components/src/DurationPicker/DurationPicker.js
+++ b/packages/axiom-components/src/DurationPicker/DurationPicker.js
@@ -61,6 +61,12 @@ const formatTimeUnit = (timeUnit) => {
   return `${timeUnit.slice(0, 1).toUpperCase()}${timeUnit.slice(1)}`;
 };
 
+const getFilteredTimeUnits = (excludedOptions) =>
+  validTimeUnits.filter((timeUnit) => !excludedOptions.includes(timeUnit));
+
+const getDefaultTimeUnit = (filteredTimeUnits) =>
+  filteredTimeUnits.includes("days") ? "days" : filteredTimeUnits[0];
+
 export default class DurationPicker extends Component {
   static propTypes = {
     /** Excluded time-unit options */
@@ -89,6 +95,12 @@ export default class DurationPicker extends Component {
     this.onChange = this.onChange.bind(this);
 
     this.state = getStateFromIsoDurationValue(props.value);
+
+    if (!this.state.selectedUnit) {
+      const filteredTimeUnits = getFilteredTimeUnits(props.excludedOptions);
+
+      this.state.selectedUnit = getDefaultTimeUnit(filteredTimeUnits);
+    }
   }
 
   onBlur() {
@@ -149,14 +161,9 @@ export default class DurationPicker extends Component {
       "value",
       "onChange",
     ]);
-    const filteredTimeUnits = validTimeUnits.filter(
-      (timeUnit) => !excludedOptions.includes(timeUnit)
-    );
-
+    const filteredTimeUnits = getFilteredTimeUnits(excludedOptions);
     const {
-      selectedUnit = filteredTimeUnits.includes("days")
-        ? "days"
-        : filteredTimeUnits[0],
+      selectedUnit = getDefaultTimeUnit(filteredTimeUnits),
       selectedValue = "",
     } = this.state;
 


### PR DESCRIPTION
when the default selected value is passed in as an empty string/undefined
the duration picker does not save the default selected unit to state.
here we make sure we init the selected unit properly in state even if the
numeric value is undefined.

Without this pr the user has to reselect the unit from dropdown to get a valid duration (if the component is initialised with a blank/undefined value).

I have been able to reproduce this functionality locally on storybook.
- change the story book component for DurationPicker to not set an inital state (eg: `useState('')`)
- run story book, select duration picker.
- set a numeric value (eg: `7` in the input box)
- view that the duration printed underneath the component is undefined.
- checkout branch
- go through same steps and view that the correct duration is printed.