### PR TITLE
fix: 🐛 Update css rule to handle disabled for TableHeaderLabel

### DIFF
--- a/packages/axiom-components/src/Table/Table.css
+++ b/packages/axiom-components/src/Table/Table.css
@@ -87,7 +87,7 @@
   color: var(--color-theme-text);
 }
 
-.ax-table__header-button:disabled {
+.ax-table__header-button--disabled {
   cursor: auto;
 }
 
@@ -114,7 +114,7 @@
   transform: scaleX(1) translateY(var(--spacing-grid-size--x2));
 }
 
-.ax-table__header-button:hover:not(:disabled) {
+.ax-table__header-button:hover:not(.ax-table__header-button--disabled) {
   color: var(--color-ui-accent--hover);
 }
 

--- a/packages/axiom-components/src/Table/Table.stories.js
+++ b/packages/axiom-components/src/Table/Table.stories.js
@@ -22,7 +22,9 @@ export function Default() {
   return (
     <Table>
       <TableHeader>
-        <TableHeaderLabel sortDirection="ascending">Column A</TableHeaderLabel>
+        <TableHeaderLabel sortDirection="ascending" onClick={() => {}}>
+          Column A
+        </TableHeaderLabel>
         <TableHeaderLabel>lower case</TableHeaderLabel>
         <TableHeaderLabel wrap={true}>
           Super long Column C label with wrapping Lorem ipsum

--- a/packages/axiom-components/src/Table/TableHeaderLabel.js
+++ b/packages/axiom-components/src/Table/TableHeaderLabel.js
@@ -65,13 +65,17 @@ export default class TableHeaderLabel extends Component {
       width: `${Math.max(0, Math.min(width, 100))}%`,
     };
 
+    const buttonClasses = classnames("ax-table__header-button", {
+      "ax-table__header-button--disabled": !onClick,
+    });
+
     return (
       <Base {...rest} Component="th" className={classes} style={styles}>
         <div
-          className="ax-table__header-button"
-          disabled={!onClick}
+          className={buttonClasses}
           onClick={onClick}
           role="button"
+          aria-disabled={!onClick}
         >
           {wrap ? (
             <EllipsisTooltip className="ax-table__header-tooltip--wrap">

--- a/packages/axiom-components/src/Table/__snapshots__/TableHeader.test.js.snap
+++ b/packages/axiom-components/src/Table/__snapshots__/TableHeader.test.js.snap
@@ -9,8 +9,8 @@ exports[`TableHeader renders 1`] = `
       className="ax-table__header-label ax-table__header-label--align-left"
     >
       <div
-        className="ax-table__header-button"
-        disabled={true}
+        aria-disabled={true}
+        className="ax-table__header-button ax-table__header-button--disabled"
         role="button"
       >
         Test

--- a/packages/axiom-components/src/Table/__snapshots__/TableHeaderLabel.test.js.snap
+++ b/packages/axiom-components/src/Table/__snapshots__/TableHeaderLabel.test.js.snap
@@ -5,8 +5,8 @@ exports[`TableHeaderLabel renders 1`] = `
   className="ax-table__header-label ax-table__header-label--align-left"
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -34,8 +34,8 @@ exports[`TableHeaderLabel renders with grow 1`] = `
   className="ax-table__header-label ax-table__header-label--align-left ax-table__header-label--grow"
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -63,8 +63,8 @@ exports[`TableHeaderLabel renders with shrink 1`] = `
   className="ax-table__header-label ax-table__header-label--align-left ax-table__header-label--shrink"
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -92,8 +92,8 @@ exports[`TableHeaderLabel renders with sortDirection 1`] = `
   className="ax-table__header-label ax-table__header-label--align-left ax-table__header-label--selected"
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -121,8 +121,8 @@ exports[`TableHeaderLabel renders with sortable 1`] = `
   className="ax-table__header-label ax-table__header-label--align-left"
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -135,8 +135,8 @@ exports[`TableHeaderLabel renders with textAlign 1`] = `
   className="ax-table__header-label ax-table__header-label--align-right"
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -169,8 +169,8 @@ exports[`TableHeaderLabel renders with width 1`] = `
   }
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -198,8 +198,8 @@ exports[`TableHeaderLabel renders with wrap 1`] = `
   className="ax-table__header-label ax-table__header-label--align-left"
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     <div
@@ -237,8 +237,8 @@ exports[`TableHeaderLabel width overrides grow 1`] = `
   }
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test
@@ -271,8 +271,8 @@ exports[`TableHeaderLabel width overrides shrink 1`] = `
   }
 >
   <div
-    className="ax-table__header-button"
-    disabled={true}
+    aria-disabled={true}
+    className="ax-table__header-button ax-table__header-button--disabled"
     role="button"
   >
     Test


### PR DESCRIPTION
Css selector for handling cursor and color for TableHeaderLabel was only checking `:disabled` pseudo class, but the pseudo class `:disabled` is only available for input elements. TableHeaderLabel is a div, and to make css selector target it, I also added the attribute selector to the css rule.