### PR TITLE
feat(axiom-components): add tiny option for progress components

### DIFF
--- a/packages/axiom-components/src/Progress/Progress.js
+++ b/packages/axiom-components/src/Progress/Progress.js
@@ -13,7 +13,7 @@ export default class Progress extends Component {
     /** Percentage of progress */
     percent: PropTypes.number,
     /** Size of the indicator */
-    size: PropTypes.oneOf(["small", "medium", "large"]),
+    size: PropTypes.oneOf(["tiny", "small", "medium", "large"]),
     /** Size in REM units */
     sizeRem: PropTypes.string,
   };

--- a/packages/axiom-components/src/Progress/ProgressFinite.js
+++ b/packages/axiom-components/src/Progress/ProgressFinite.js
@@ -10,7 +10,7 @@ export default class ProgressFinite extends Component {
     /** Percentage of progress complete */
     percent: PropTypes.number.isRequired,
     /** Size of the indicator */
-    size: PropTypes.oneOf(["small", "medium", "large"]),
+    size: PropTypes.oneOf(["tiny", "small", "medium", "large"]),
     /** Size in REM units */
     sizeRem: PropTypes.string,
   };

--- a/packages/axiom-components/src/Progress/ProgressInfinite.js
+++ b/packages/axiom-components/src/Progress/ProgressInfinite.js
@@ -12,7 +12,7 @@ export default class ProgressInfinite extends Component {
     /** Color of the indicator */
     color: PropTypes.oneOf(["subtle", "white"]),
     /** Size of the indicator */
-    size: PropTypes.oneOf(["small", "medium", "large"]),
+    size: PropTypes.oneOf(["tiny", "small", "medium", "large"]),
     /** Size in REM units */
     sizeRem: PropTypes.string,
   };

--- a/packages/axiom-components/src/Progress/RadialProgress.css
+++ b/packages/axiom-components/src/Progress/RadialProgress.css
@@ -4,6 +4,11 @@
   margin-left: auto;
 }
 
+.ax-radial-progress--tiny {
+  width: var(--component-round-size-tiny);
+  height: var(--component-round-size-tiny);
+}
+
 .ax-radial-progress--small {
   width: var(--component-round-size-small);
   height: var(--component-round-size-small);

--- a/packages/axiom-components/src/Progress/RadialProgress.test.js
+++ b/packages/axiom-components/src/Progress/RadialProgress.test.js
@@ -17,7 +17,7 @@ describe("RadialProgress", () => {
   });
 
   describe("renders with size", () => {
-    ["small", "medium", "large"].forEach((size) => {
+    ["tiny", "small", "medium", "large"].forEach((size) => {
       it(size, () => {
         const component = getComponent({ size });
         const tree = component.toJSON();

--- a/packages/axiom-components/src/Progress/__snapshots__/RadialProgress.test.js.snap
+++ b/packages/axiom-components/src/Progress/__snapshots__/RadialProgress.test.js.snap
@@ -55,3 +55,17 @@ exports[`RadialProgress renders with size small 1`] = `
   </g>
 </svg>
 `;
+
+exports[`RadialProgress renders with size tiny 1`] = `
+<svg
+  className="lorem ax-radial-progress ax-radial-progress--tiny"
+  style={Object {}}
+  viewBox="0 0 75 75"
+>
+  <g
+    transform="translate(37.5, 37.5) rotate(-90)"
+  >
+    <svg />
+  </g>
+</svg>
+`;


### PR DESCRIPTION
adds a `tiny` option to the Progress components to match the AlertIcon sizes