### PR TITLE
fix(axiom-components): fix horizontalPadding in TableCell

### DIFF
--- a/packages/axiom-components/src/Table/Table.css
+++ b/packages/axiom-components/src/Table/Table.css
@@ -41,13 +41,13 @@
 }
 
 .ax-table__cell--horizontal-padding-none {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding-right: 0;
+  padding-left: 0;
 }
 
 .ax-table__cell--horizontal-padding-medium {
-  padding-top: var(--spacing-grid-size--x4);
-  padding-bottom: var(--spacing-grid-size--x4);
+  padding-right: var(--spacing-grid-size--x4);
+  padding-left: var(--spacing-grid-size--x4);
 }
 
 .ax-table__cell--vertical-padding-none {


### PR DESCRIPTION
While experimenting with nesting tables I've stumbled over an issue when trying to set `horizontalPadding="none"` to a table cell, that did not work as expected.

See this [sandbox](https://codesandbox.io/s/axiom-tablecell-horizontalpadding-none-bug-sc5n0). This PR fixes the wrong usage of css properties for both the `none` case and `medium` case (which is the default anyways).


