### PR TITLE
Update style of invalid TextInputs

### DIFF
--- a/packages/axiom-components/src/Form/TextInput.stories.js
+++ b/packages/axiom-components/src/Form/TextInput.stories.js
@@ -78,7 +78,7 @@ export function WithTooltipIcon() {
       <TextInputIcon
         align="right"
         iconColor="error"
-        name="information-circle"
+        name="warning-circle"
         tooltip="This username exists, please select a different one"
       />
     </TextInput>

--- a/packages/axiom-materials/src/opacities.css
+++ b/packages/axiom-materials/src/opacities.css
@@ -17,5 +17,5 @@
 
   --opacity-input-border--focused: 0.5;
   --opacity-input-border--valid: 0.4;
-  --opacity-input-border--invalid: 0.25;
+  --opacity-input-border--invalid: 0.75;
 }


### PR DESCRIPTION
This PR improves the visibility of invalid TextInputs:

- Set opacity-input-border--invalid to 0.75
- Use warning-circle for invalid TextInputs

![image](https://user-images.githubusercontent.com/423234/125802464-203422ec-b490-4c27-8ef9-f2cc42fffb2f.png)

CC @Flawwles 