### PR TITLE
Use dark style tooltips for text input icons"

### DIFF
--- a/packages/axiom-components/src/Form/TextInputIcon.js
+++ b/packages/axiom-components/src/Form/TextInputIcon.js
@@ -17,18 +17,36 @@ export default class TextInputIcon extends Component {
     onClick: PropTypes.func,
     /** Optional tooltip for the icon. */
     tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    /** Optional tooltip color. Default is "carbon" */
+    tooltipColor: PropTypes.oneOf([
+      "success",
+      "warning",
+      "error",
+      "info",
+      "carbon",
+      "white",
+    ]),
   };
 
   static typeRef = TextInputIconRef;
 
   render() {
-    const { align, iconColor, name, onClick, tooltip, ...rest } = this.props;
+    const {
+      align,
+      iconColor,
+      name,
+      onClick,
+      tooltip,
+      tooltipColor,
+      ...rest
+    } = this.props;
 
     return (
       <TextInputIconWrapper
         align={align}
         onClick={onClick}
         tooltip={tooltip}
+        tooltipColor={tooltipColor}
         {...rest}
       >
         <Icon name={name} textColor={iconColor} size="1rem" />

--- a/packages/axiom-components/src/Form/TextInputIconWrapper.js
+++ b/packages/axiom-components/src/Form/TextInputIconWrapper.js
@@ -22,16 +22,34 @@ export default class TextInputIconWrapper extends Component {
     onClick: PropTypes.func,
     /** Optional tooltip for the icon. */
     tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    /** Optional tooltip color. Default is "carbon" */
+    tooltipColor: PropTypes.oneOf([
+      "success",
+      "warning",
+      "error",
+      "info",
+      "carbon",
+      "white",
+    ]),
   };
 
   static defaultProps = {
     align: "right",
+    tooltipColor: "carbon",
   };
 
   static typeRef = TextInputIconWrapperRef;
 
   render() {
-    const { align, onClick, tooltip, children, ...rest } = this.props;
+    const {
+      align,
+      onClick,
+      tooltip,
+      children,
+      tooltipColor,
+      ...rest
+    } = this.props;
+
     const className = classnames("ax-input__icon", {
       [`ax-input__icon--align-${align}`]: align,
     });
@@ -43,7 +61,7 @@ export default class TextInputIconWrapper extends Component {
           {isComponent(tooltip, TooltipContextRef) ? (
             tooltip
           ) : (
-            <TooltipContext>
+            <TooltipContext color={tooltipColor}>
               <TooltipContent size="tiny">{tooltip}</TooltipContent>
             </TooltipContext>
           )}


### PR DESCRIPTION
This PR update the TextInputIcon component to allow setting its color and use the dark style by default.

![image](https://user-images.githubusercontent.com/423234/125808111-9af46fe2-446c-4054-ac65-39803c9593c2.png)

CC @Flawwles 